### PR TITLE
Add CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ocaml/opam:debian-9_ocaml-4.04.2
+        environment:
+          TERM: xterm
+    steps:
+      - checkout
+      - run:
+          name: Update apt-get
+          command: sudo apt-get update
+      - run:
+          name: Update opam package list
+          # This Docker image defaults to coming with its own opam repo built
+          # in, but we want to actually update with the real upstream opam
+          command: |
+            opam remote remove default
+            opam remote add default https://opam.ocaml.org
+      - run:
+          name: Pin packages
+          command: |
+            for f in *.opam; do
+              opam pin add -yn "$f" .
+            done
+      - run:
+          name: Install system dependencies
+          command: opam depext -y $(ls -1 *.opam | sed -e 's/\.opam$//')
+      - run:
+          name: Install OCaml dependencies
+          command: opam install --deps-only -y $(ls -1 *.opam | sed -e 's/\.opam$//')
+      - run:
+          name: Build
+          command: opam config exec -- jbuilder build @install
+      - run:
+          name: Test
+          command: opam config exec -- jbuilder runtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ jobs:
       - image: ocaml/opam:debian-9_ocaml-4.04.2
         environment:
           TERM: xterm
+      - image: circleci/postgres:alpine-ram
+        environment:
+          POSTGRES_USER: test
+          POSTGRES_DB: test
+          POSTGRES_PASSWORD: ""
+
     steps:
       - checkout
       - run:
@@ -34,4 +40,9 @@ jobs:
           command: opam config exec -- jbuilder build @install
       - run:
           name: Test
-          command: opam config exec -- jbuilder runtest
+          command: |
+            echo "
+                sqlite3::memory:
+                postgresql://test@localhost/test
+            " > tests/uris.conf
+            opam config exec -- jbuilder runtest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/paurkedal/ocaml-caqti.svg?style=svg)](https://circleci.com/gh/paurkedal/ocaml-caqti)
+
 ## Synopsis
 
 Caqti provides a monadic cooperative-threaded OCaml connector API for


### PR DESCRIPTION
If you merge this and then add this project in CircleCI, you'll get CI builds with basically no effort. We could make it faster by making a custom base image, but for a build that takes 3.5 minutes, it doesn't seem worth the effort.