### PR TITLE
Change Deferred.Or_error.all_unit to all_ignore

### DIFF
--- a/lib-async/caqti1_async.ml
+++ b/lib-async/caqti1_async.ml
@@ -25,7 +25,7 @@ module System = struct
   let (>|=) = Deferred.Or_error.(>>|)
   let return = Deferred.Or_error.return
   let fail = Deferred.Or_error.of_exn
-  let join = Deferred.Or_error.all_unit
+  let join = Deferred.Or_error.all_ignore
 
   let catch f g =
     let open Deferred in


### PR DESCRIPTION
This function was renamed to all_unit in Async v0.11, but the opam
file says Caqti supports v0.10. all_ignore still exists in v0.11
and is just deprecated.

https://ocaml.janestreet.com/ocaml-core/v0.10/doc/base/Base__/Monad_intf/module-type-S_without_syntax/
https://ocaml.janestreet.com/ocaml-core/v0.11/doc/base/Base__/Monad_intf/module-type-S_without_syntax/