### PR TITLE
Support Lwt 4.0

### DIFF
--- a/caqti-lwt.opam
+++ b/caqti-lwt.opam
@@ -15,5 +15,6 @@ depends: [
   "caqti-dynload" {test & >= "0.10.2"}
   "caqti-driver-sqlite3" {test & >= "0.10.2"}
   "jbuilder" {build & >= "1.0+beta19"}
-  "lwt"
+  "lwt" {>= "3.2.0"}
+  "lwt_log"
 ]

--- a/lib-lwt/jbuild
+++ b/lib-lwt/jbuild
@@ -5,7 +5,7 @@
   (public_name caqti-lwt)
   (wrapped false)
   (modules (Caqti_lwt Caqti_lwt_sql_io))
-  (libraries (caqti lwt lwt.unix lwt.preemptive))))
+  (libraries (caqti lwt lwt.unix lwt_log))))
 
 (library
  ((name caqti_lwt_v1)


### PR DESCRIPTION
According to the release notes for Lwt 4.0, lwt.preemptive is an alias
for lwt.unix since 3.2.0, and they removed the alias in 4.0.

Also, Lwt_log was moved to a separate opam package.

https://github.com/ocsigen/lwt/releases/tag/4.0.0