### PR TITLE
Clarify documentation of CONNECTION's iterators

### DIFF
--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -142,7 +142,8 @@ module type S = sig
     ('b -> 'c -> ('c, 'e) result future) ->
     'a -> 'c -> ('c, [> Caqti_error.call_or_retrieve] as 'e) result future
   (** Combining {!call} with {!Response.fold_s}, this sends a request to the
-      database and folds concurrently over the result rows.
+      database and folds sequentially over the result rows in a non-blocking
+      manner.
 
       Please be aware of possible deadlocks when using resources from the
       callback.  In particular, if the same connection pool is invoked as the
@@ -155,8 +156,8 @@ module type S = sig
     ('b -> (unit, 'e) result future) ->
     'a -> (unit, [> Caqti_error.call_or_retrieve] as 'e) result future
   (** Combining {!call} with {!Response.iter_s}, this sends a request to the
-      database and iterates concurrently over the result rows.  Please see the
-      warning in {!fold_s} about resource usage in the callback. *)
+      database and iterates sequentially over the result rows in a non-blocking manner.
+      Please see the warning in {!fold_s} about resource usage in the callback. *)
 
   val collect_list :
     ('a, 'b, [< `Zero | `One | `Many]) Caqti_request.t -> 'a ->


### PR DESCRIPTION
While working with `caqti` I got confused by the documentation as it seemed to use the same suffixes as `Lwt` but a different terminology. In particular the use of "concurrently" made it unclear whether `iter_s`
was an actual `iter_s` or `iter_p` and thus whether it would apply to the rows in order or not.

I made some changes to the documentation of `fold`, `fold_s` and `iter_s` after looking at the source to understand what their actual behaviour was.

The wording might not be perfect but I'd love to hear your thoughts on this and whether you think it's indeed an improvement or not!