### PR TITLE
Use the postgresql driver when postgres is specified as the URI schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Use the postgres driver when `postgres` is specified as the URL scheme (James Owen).
+
 ## v1.1.0 - 2019-02-03
 
 - Add pretty printer for requests.

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -684,4 +684,6 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
                 Ok (module Connection : CONNECTION))))
 end
 
-let () = Caqti_connect.define_unix_driver "postgresql" (module Connect_functor)
+let () =
+  Caqti_connect.define_unix_driver "postgres" (module Connect_functor);
+  Caqti_connect.define_unix_driver "postgresql" (module Connect_functor)

--- a/lib/caqti_connect.ml
+++ b/lib/caqti_connect.ml
@@ -26,10 +26,14 @@ let define_loader f = dynload_library := f
 let drivers = Hashtbl.create 11
 let define_unix_driver scheme p = Hashtbl.add drivers scheme p
 
+let scheme_driver_name = function
+  | "postgres" | "postgresql" -> "caqti-driver-postgresql"
+  | s -> "caqti-driver-" ^ s
+
 let load_driver_functor ~uri scheme =
   (try Ok (Hashtbl.find drivers scheme) with
    | Not_found ->
-      (match !dynload_library ("caqti-driver-" ^ scheme) with
+      (match !dynload_library (scheme_driver_name scheme) with
        | Ok () ->
           (try Ok (Hashtbl.find drivers scheme) with
            | Not_found ->


### PR DESCRIPTION
This is a small PR to fix an issue that has been causing us a bit of trouble when trying to use `caqti`.

In the postgres documentation [here](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) it states that valid postgres URIs can use either the `postgresql` or `postgres` scheme. It seems like the `postgres` scheme is quite common, for example when deploying to heroku.

The fix here is to handle the special case when resolving the driver name at connect time, and for the `caqti-driver-postgresql` library to register itself for both schemes.

I would be interested in your thoughts/feedback on this, including whether registering the driver twice is indeed the right approach - it is definitely the simplest, but there might be a nicer way.
