### PR TITLE
WIP: Add copy mode

### DIFF
--- a/lib-driver/caqti_driver_mariadb.ml
+++ b/lib-driver/caqti_driver_mariadb.ml
@@ -382,6 +382,10 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
           | Ok None -> return Stream.Nil
           | Error err -> return (Stream.Error err)
           | Ok (Some y) -> return (Stream.Cons (y, to_stream resp)))
+
+      let from_stream _ _stream =
+        let msg = Caqti_error.Msg "from_stream not implemented" in
+        return (Error (Caqti_error.not_implemented ~uri msg))
     end
 
     type pcache_entry = {

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -597,6 +597,10 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
            | Ok y -> return @@ Stream.Cons (y, f (i + 1))
            | Error err -> return @@ Stream.Error err) in
         f 0
+
+      let from_stream _ _stream =
+        let msg = Caqti_error.Msg "from_stream not implemented" in
+        return (Error (Caqti_error.not_implemented ~uri msg))
     end
 
     let call ~f req param =

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -29,6 +29,14 @@ let () =
    | _ -> assert false in
   Caqti_error.define_msg ~pp [%extension_constructor Pg_msg]
 
+let stream_in_builder ~table_name:_ ~columns:_ =
+  (* Create a COPY INTO table_name (columns) query to execute *)
+  failwith "Unimplemented"
+
+let stream_out_builder ~table_name:_ ~columns:_ =
+  (* Create a COPY FROM table_name (columns) query to execute *)
+  failwith "Unimplemented"
+
 let driver_info =
   Caqti_driver_info.create
     ~uri_scheme:"postgresql"
@@ -39,6 +47,8 @@ let driver_info =
     ~can_transact:true
     ~describe_has_typed_params:true
     ~describe_has_typed_fields:true
+    ~stream_in_builder
+    ~stream_out_builder
     ()
 
 module Pg_ext = struct
@@ -590,6 +600,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
         loop 0 ()
 
       let to_stream {row_type; result} =
+        (* This needs to somehow handle copying out based on the value of result *)
         let n = result#ntuples in
         let rec f i () =
           if i = n then return Stream.Nil else
@@ -599,6 +610,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
         f 0
 
       let from_stream _ _stream =
+        (* Check the response allows us to copy, then stream in the serialized items *)
         let msg = Caqti_error.Msg "from_stream not implemented" in
         return (Error (Caqti_error.not_implemented ~uri msg))
     end

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -53,9 +53,9 @@ module Pg_ext = struct
   let query_string templ =
     let buf = Buffer.create 64 in
     let rec loop = function
-     | Caqti_request.L s -> Buffer.add_string buf s
-     | Caqti_request.P i -> bprintf buf "$%d" (i + 1)
-     | Caqti_request.S frags -> List.iter loop frags in
+     | Caqti_sql.L s -> Buffer.add_string buf s
+     | Caqti_sql.P i -> bprintf buf "$%d" (i + 1)
+     | Caqti_sql.S frags -> List.iter loop frags in
     loop templ;
     Buffer.contents buf
 

--- a/lib-driver/caqti_driver_sqlite3.ml
+++ b/lib-driver/caqti_driver_sqlite3.ml
@@ -379,6 +379,10 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
         | Ok None -> return Stream.Nil
         | Error err -> return (Stream.Error err)
         | Ok (Some y) -> return (Stream.Cons (y, to_stream resp))
+
+      let from_stream _ _stream =
+        let msg = Caqti_error.Msg "from_stream not implemented" in
+        return (Error (Caqti_error.not_implemented ~uri msg))
     end
 
     let pcache = Hashtbl.create 19

--- a/lib-driver/caqti_driver_sqlite3.ml
+++ b/lib-driver/caqti_driver_sqlite3.ml
@@ -18,6 +18,14 @@ open Caqti_prereq
 open Caqti_driver_lib
 open Printf
 
+let stream_in_builder ~table_name:_ ~columns:_ =
+  (* Create an INSERT INTO table_name (columns) VALUES (?,..) query to be prepared *)
+  failwith "Unimplemented"
+
+let stream_out_builder ~table_name:_ ~columns:_ =
+  (* Create a normal SELECT columns FROM table_name query *)
+  failwith "Unimplemented"
+
 let driver_info =
   Caqti_driver_info.create
     ~uri_scheme:"sqlite3"
@@ -28,6 +36,8 @@ let driver_info =
     ~can_transact:true
     ~describe_has_typed_params:false
     ~describe_has_typed_fields:true
+    ~stream_in_builder
+    ~stream_out_builder
     ()
 
 let get_uri_bool uri name =
@@ -380,7 +390,8 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
         | Error err -> return (Stream.Error err)
         | Ok (Some y) -> return (Stream.Cons (y, to_stream resp))
 
-      let from_stream _ _stream =
+      let from_stream _resp stream =
+        (* Begin a transaction, call the prepared query for every item, end the transaction *)
         let msg = Caqti_error.Msg "from_stream not implemented" in
         return (Error (Caqti_error.not_implemented ~uri msg))
     end

--- a/lib/caqti_connect.ml
+++ b/lib/caqti_connect.ml
@@ -111,6 +111,13 @@ module Make_unix (System : Caqti_driver_sig.System_unix) = struct
       let f resp = Response.fold List.cons resp [] in
       call ~f q p
 
+    let from_stream q s =
+      let f resp = Response.from_stream resp s in
+      call
+        ~f
+        (Caqti_request.collapse q)
+        (Caqti_request.counit ())
+
     let start () = use C.start
     let commit () = use C.commit
     let rollback () = use C.rollback

--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -174,4 +174,15 @@ module type S = sig
       extracting the result as a reversed list.  This is more efficient than
       {!find_list} and fits well with a subsequent {!List.rev_map}, though it
       may not matter much in practise. *)
+
+  (** {2 Insertion Convenience}
+
+      These are shortcuts for {!call} combined with insertion functions from
+      {!Caqti_response_sig.S} of the same name. *)
+
+  val from_stream :
+    (Caqti_request.counit, 'row_type, Caqti_request.counit, [`Many_in]) Caqti_request.t4 ->
+    ('row_type, unit) stream ->
+    (unit, [> Caqti_error.call | Caqti_error.driver] as 'e) result future
+
 end

--- a/lib/caqti_driver_info.ml
+++ b/lib/caqti_driver_info.ml
@@ -20,6 +20,7 @@ type parameter_style =
   [ `None
   | `Linear of string
   | `Indexed of (int -> string) ]
+type query_builder = table_name: string -> columns: string list -> Caqti_sql.query
 
 type t = {
   index: int;
@@ -31,6 +32,8 @@ type t = {
   can_transact: bool;
   can_pool: bool;
   can_concur: bool;
+  stream_in_builder: query_builder option;
+  stream_out_builder: query_builder option;
 }
 
 let next_backend_index = ref 0
@@ -44,6 +47,8 @@ let create
     ~can_transact
     ~describe_has_typed_params
     ~describe_has_typed_fields
+    ?stream_in_builder
+    ?stream_out_builder
     () =
   {
     index = (let i = !next_backend_index in incr next_backend_index; i);
@@ -55,6 +60,8 @@ let create
     can_transact;
     can_pool;
     can_concur;
+    stream_in_builder;
+    stream_out_builder;
   }
 
 let dummy = create
@@ -68,5 +75,7 @@ let parameter_style di = di.parameter_style
 let can_pool di = di.can_pool
 let can_concur di = di.can_concur
 let can_transact di = di.can_transact
+let stream_in_builder di = di.stream_in_builder
+let stream_out_builder di = di.stream_out_builder
 let describe_has_typed_params di = di.describe_has_typed_params
 let describe_has_typed_fields di = di.describe_has_typed_fields

--- a/lib/caqti_driver_info.mli
+++ b/lib/caqti_driver_info.mli
@@ -40,6 +40,10 @@ type parameter_style = private [>
     - [`Indexed f] means that an occurrence of [f i] represents parameter
       number [i], counting from 0. *)
 
+type query_builder = table_name: string -> columns: string list -> Caqti_sql.query
+(** [query_builder] functions are functions that build [query] instances based on the provided
+    table name and list of column names. The exact query produced depends on the context. *)
+
 type t
 
 val create :
@@ -51,6 +55,8 @@ val create :
   can_transact: bool ->
   describe_has_typed_params: bool ->
   describe_has_typed_fields: bool ->
+  ?stream_in_builder: query_builder ->
+  ?stream_out_builder: query_builder ->
   unit -> t
 (** The function used by drivers to construct a description of themselves.  For
     an explanation of the parameters, see the corresponding projections. *)
@@ -85,6 +91,12 @@ val can_concur : t -> bool
 
 val can_transact : t -> bool
 (** Whether the database and driver supports transactions. *)
+
+val stream_in_builder : t -> query_builder option
+(** If supported, return a query builder for building stream in queries. *)
+
+val stream_out_builder : t -> query_builder option
+(** If supported, return a query builder for building stream out queries. *)
 
 (**/**)
 

--- a/lib/caqti_driver_lib.ml
+++ b/lib/caqti_driver_lib.ml
@@ -18,32 +18,32 @@ open Caqti_prereq
 
 let linear_param_length templ =
   let rec loop = function
-   | Caqti_request.L _ -> ident
-   | Caqti_request.P _ -> succ
-   | Caqti_request.S frags -> List.fold loop frags in
+   | Caqti_sql.L _ -> ident
+   | Caqti_sql.P _ -> succ
+   | Caqti_sql.S frags -> List.fold loop frags in
   loop templ 0
 
 let nonlinear_param_length templ =
   let rec loop = function
-   | Caqti_request.L _ -> ident
-   | Caqti_request.P n -> max (n + 1)
-   | Caqti_request.S frags -> List.fold loop frags in
+   | Caqti_sql.L _ -> ident
+   | Caqti_sql.P n -> max (n + 1)
+   | Caqti_sql.S frags -> List.fold loop frags in
   loop templ 0
 
 let linear_param_order templ =
   let a = Array.make (nonlinear_param_length templ) [] in
   let rec loop = function
-   | Caqti_request.L _ -> fun j -> j
-   | Caqti_request.P i -> fun j -> a.(i) <- j :: a.(i); j + 1
-   | Caqti_request.S frags -> List.fold loop frags in
+   | Caqti_sql.L _ -> fun j -> j
+   | Caqti_sql.P i -> fun j -> a.(i) <- j :: a.(i); j + 1
+   | Caqti_sql.S frags -> List.fold loop frags in
   let _ = loop templ 0 in
   Array.to_list a
 
 let linear_query_string templ =
   let buf = Buffer.create 64 in
   let rec loop = function
-   | Caqti_request.L s -> Buffer.add_string buf s
-   | Caqti_request.P _ -> Buffer.add_char buf '?'
-   | Caqti_request.S frags -> List.iter loop frags in
+   | Caqti_sql.L s -> Buffer.add_string buf s
+   | Caqti_sql.P _ -> Buffer.add_char buf '?'
+   | Caqti_sql.S frags -> List.iter loop frags in
   loop templ;
   Buffer.contents buf

--- a/lib/caqti_driver_lib.mli
+++ b/lib/caqti_driver_lib.mli
@@ -16,15 +16,15 @@
 
 (** {b Internal:} Library for Drivers *)
 
-val linear_param_length : Caqti_request.query -> int
+val linear_param_length : Caqti_sql.query -> int
 (** [linear_param_length templ] is the number of linear parameters expected by a
     query represented by [templ]. *)
 
-val linear_param_order : Caqti_request.query -> int list list
+val linear_param_order : Caqti_sql.query -> int list list
 (** [linear_param_order templ] is a list where item number [i] is a list of
     positions of the linearized query which refer to the [i]th incoming
     parameter.  Positions are zero-based. *)
 
-val linear_query_string : Caqti_request.query -> string
+val linear_query_string : Caqti_sql.query -> string
 (** [linear_query_string templ] is [templ] where ["?"] is substituted for
     parameters. *)

--- a/lib/caqti_error.mli
+++ b/lib/caqti_error.mli
@@ -53,6 +53,10 @@ type load_error = private {
   uri: Uri.t;
   msg: msg;
 }
+type driver_error = private {
+  uri: Uri.t;
+  msg: msg;
+}
 type connection_error = private {
   uri: Uri.t;
   msg: msg;
@@ -82,6 +86,11 @@ val load_failed : uri: Uri.t -> msg -> [> `Load_failed of load_error]
 (** [load_failed ~uri msg] indicates that a driver for [uri] could not be
     loaded. *)
 
+(** {3 Errors during driver operation} *)
+
+val not_implemented : uri: Uri.t -> msg -> [> `Not_implemented of driver_error]
+(** [not_implemented msg] indicates that the driver for [uri] does not implement
+    the requested method. *)
 
 (** {3 Errors during Connect} *)
 
@@ -177,10 +186,13 @@ type connect =
 
 type load_or_connect = [load | connect]
 
+type driver =
+  [ `Not_implemented of driver_error ]
+
 
 (** {2 Generic Error Type and Functions} *)
 
-type t = [load | connect | call | retrieve]
+type t = [load | connect | call | retrieve | driver]
 (** The full union of errors used by Caqti. *)
 
 val uri : [< t] -> Uri.t

--- a/lib/caqti_mult.ml
+++ b/lib/caqti_mult.ml
@@ -21,17 +21,20 @@ type +'m t = (* not GADT due to variance *)
  | One
  | Zero_or_one
  | Zero_or_more
-constraint 'm = [< `Zero | `One | `Many]
+ | Zero_or_more_in
+constraint 'm = [< `Zero | `One | `Many | `Many_in]
 
 type zero = [`Zero]
 type one = [`One]
 type zero_or_one = [`Zero | `One]
 type zero_or_more = [`Zero | `One | `Many]
+type zero_or_more_in = [`Many_in]
 
 let zero : [> `Zero] t = Zero
 let one : [> `One] t = One
 let zero_or_one : [> `Zero | `One] t = Zero_or_one
 let zero_or_more : ([> `Zero | `One | `Many] as 'a) t = Zero_or_more
+let zero_or_more_in : [> `Many_in] t = Zero_or_more_in
 
 let only_zero : [< `Zero] t -> unit =
   function Zero -> () | _ -> assert false
@@ -45,3 +48,4 @@ let expose = function
  | One -> `One
  | Zero_or_one -> `Zero_or_one
  | Zero_or_more -> `Zero_or_more
+ | Zero_or_more_in -> `Zero_or_more_in

--- a/lib/caqti_mult.mli
+++ b/lib/caqti_mult.mli
@@ -16,20 +16,22 @@
 
 (** Row multiplicity. *)
 
-type +'m t constraint 'm = [< `Zero | `One | `Many]
+type +'m t constraint 'm = [< `Zero | `One | `Many | `Many_in]
 
 type zero = [`Zero]
 type one = [`One]
 type zero_or_one = [`Zero | `One]
 type zero_or_more = [`Zero | `One | `Many]
+type zero_or_more_in = [`Many_in]
 
 val zero : [> `Zero] t
 val one : [> `One] t
 val zero_or_one : [> `Zero | `One] t
 val zero_or_more : [> `Zero | `One | `Many] t
+val zero_or_more_in : [> `Many_in] t
 
 val only_zero : [< `Zero] t -> unit
 val only_one : [< `One] t -> unit
 val only_zero_or_one : [< `Zero | `One] t -> unit
 
-val expose : 'm t -> [`Zero | `One | `Zero_or_one | `Zero_or_more]
+val expose : 'm t -> [`Zero | `One | `Zero_or_one | `Zero_or_more | `Zero_or_more_in]

--- a/lib/caqti_request.ml
+++ b/lib/caqti_request.ml
@@ -41,9 +41,12 @@ type ('params, 'output, +'mult) t = ('params, counit, 'output, 'mult) t4
 
 let last_id = ref (-1)
 
-let create ?(oneshot = false) param_type output_type row_mult query =
+let create_full ?(oneshot = false) param_type input_type output_type row_mult query =
   let id = if oneshot then None else (incr last_id; Some !last_id) in
-  {id; query; param_type; input_type = Caqti_type.Std.unit; output_type; row_mult}
+  {id; query; param_type; input_type; output_type; row_mult}
+
+let create ?(oneshot = false) param_type output_type row_mult query =
+  create_full ~oneshot param_type Caqti_type.Std.unit output_type row_mult query
 
 let param_type request = request.param_type
 let input_type request = request.input_type

--- a/lib/caqti_request.ml
+++ b/lib/caqti_request.ml
@@ -42,6 +42,8 @@ let create_full ?(oneshot = false) param_type input_type output_type row_mult qu
 let create ?(oneshot = false) param_type output_type row_mult query =
   create_full ~oneshot param_type Caqti_type.Std.unit output_type row_mult query
 
+let collapse full = {full with input_type = Caqti_type.Std.unit}
+
 let param_type request = request.param_type
 let input_type request = request.input_type
 let output_type request = request.output_type

--- a/lib/caqti_request.ml
+++ b/lib/caqti_request.ml
@@ -185,6 +185,7 @@ let pp ppf req =
      | `Zero -> "!"
      | `One -> ""
      | `Zero_or_one -> "?"
-     | `Zero_or_more -> "*")
+     | `Zero_or_more -> "*"
+     | `Zero_or_more_in -> "<*")
     Caqti_type.pp (row_type req)
     pp_query (req.query Caqti_driver_info.dummy)

--- a/lib/caqti_request.ml
+++ b/lib/caqti_request.ml
@@ -20,6 +20,8 @@ type query = Caqti_sql.query
 
 type counit = unit
 
+let counit () = ()
+
 type ('params, 'input, 'output, +'mult) t4 = {
   id: int option;
   query: Caqti_driver_info.t -> query;

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -57,6 +57,21 @@ type ('params, 'output, +'mult) t = ('params, counit, 'output, 'mult) t4
     - ['output] is the type of a returned row.
     - ['multiplicity] is the possible multiplicities of returned rows. *)
 
+val create_full :
+  ?oneshot: bool ->
+  'params Caqti_type.t ->
+  'input Caqti_type.t ->
+  'output Caqti_type.t ->
+  'mult Caqti_mult.t ->
+  (Caqti_driver_info.t -> query) ->
+  ('params, 'input, 'output, 'mult) t4
+(** [create_full params_type input_type output_type row_mult f] is a request which takes
+    parameters of type [params_type], inputs rows of type [input_type] and returns rows of
+    type [output_type] with multiplicity [row_mult], and which sends query strings generated
+    from the query [f di], where [di] is the {!Caqti_driver_info.t} of the target driver.
+    The driver is responsible for turning parameter references into a form accepted by the
+    database, while other differences must be handled by [f]. *)
+
 val create :
   ?oneshot: bool ->
   'params Caqti_type.t ->

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -39,19 +39,33 @@ type query =
     denoted "[?]"), the driver will reshuffle, elide, and duplicate parameters
     as needed.  *)
 
-type ('a, 'b, +'m) t constraint 'm = [< `Zero | `One | `Many]
+type counit
+(** Empty type *)
+
+type ('params, 'input, 'output, +'mult) t4 constraint 'mult = [< `Zero | `One | `Many]
 (** A request specification embedding a query generator, parameter encoder, and
     row decoder.
-    - ['a] is the type of the expected parameter bundle.
-    - ['b] is the type of a returned row.
-    - ['m] is the possible multiplicities of returned rows. *)
+    - ['params] is the type of the expected parameter bundle.
+    - ['input] is the type of an input row.
+    - ['output] is the type of a returned row.
+    - ['mult] is the possible multiplicities of returned rows. *)
+
+type ('params, 'output, +'mult) t = ('params, counit, 'output, 'mult) t4
+(** A request specification embedding a query generator, parameter encoder, and
+    row decoder.
+    - ['params] is the type of the expected parameter bundle.
+    - ['output] is the type of a returned row.
+    - ['multiplicity] is the possible multiplicities of returned rows. *)
 
 val create :
   ?oneshot: bool ->
-  'a Caqti_type.t -> 'b Caqti_type.t -> 'm Caqti_mult.t ->
-  (Caqti_driver_info.t -> query) -> ('a, 'b, 'm) t
-(** [create arg_type row_type row_mult f] is a request which takes parameters of
-    type [arg_type], returns rows of type [row_type] with multiplicity
+  'params Caqti_type.t ->
+  'output Caqti_type.t ->
+  'mult Caqti_mult.t ->
+  (Caqti_driver_info.t -> query) ->
+  ('params, 'output, 'mult) t
+(** [create params_type row_type row_mult f] is a request which takes parameters of
+    type [params_type], returns rows of type [row_type] with multiplicity
     [row_mult], and which sends query strings generated from the query [f di],
     where [di] is the {!Caqti_driver_info.t} of the target driver.  The driver
     is responsible for turning parameter references into a form accepted by the
@@ -59,6 +73,12 @@ val create :
 
 val param_type : ('a, _, _) t -> 'a Caqti_type.t
 (** [param_type req] is the type of parameter bundles expected by [req]. *)
+
+val input_type : (_, 'input, _, _) t4 -> 'input Caqti_type.t
+(** [input_type req] is the type of rows accepted by [req]. *)
+
+val output_type : (_, _, 'output, _) t4 -> 'output Caqti_type.t
+(** [output_type req] is the type of rows returned by [req]. *)
 
 val row_type : (_, 'b, _) t -> 'b Caqti_type.t
 (** [row_type req] is the type of rows returned by [req]. *)

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -79,6 +79,9 @@ val create :
     is responsible for turning parameter references into a form accepted by the
     database, while other differences must be handled by [f]. *)
 
+val collapse : ('params, 'input, 'output, 'mult) t4 -> ('params, 'output, 'mult) t
+(** [collapse req] gives the collapsed type version of the full type [req]. *)
+
 val param_type : ('a, _, _) t -> 'a Caqti_type.t
 (** [param_type req] is the type of parameter bundles expected by [req]. *)
 

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -33,6 +33,8 @@ type query = Caqti_sql.query
 type counit
 (** Empty type *)
 
+val counit : unit -> counit
+
 type ('params, 'input, 'output, +'mult) t4 constraint 'mult = [< `Zero | `One | `Many | `Many_in]
 (** A request specification embedding a query generator, parameter encoder, and
     row decoder.

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -33,7 +33,7 @@ type query = Caqti_sql.query
 type counit
 (** Empty type *)
 
-type ('params, 'input, 'output, +'mult) t4 constraint 'mult = [< `Zero | `One | `Many]
+type ('params, 'input, 'output, +'mult) t4 constraint 'mult = [< `Zero | `One | `Many | `Many_in]
 (** A request specification embedding a query generator, parameter encoder, and
     row decoder.
     - ['params] is the type of the expected parameter bundle.
@@ -191,6 +191,30 @@ val collect :
   string -> ('a, 'b, [> `Zero | `One | `Many]) t
 (** [collect_p arg_type row_type s] is a shortcut for
     [create_p arg_type row_type Caqti_mult.many (fun _ -> s)]. *)
+
+val stream_in :
+  ?env: (Caqti_driver_info.t -> string -> query) ->
+  ?oneshot: bool ->
+  'row_type Caqti_type.t ->
+  table: string ->
+  columns: string list ->
+  unit ->
+  (counit, 'row_type, counit, [> `Many_in]) t4
+(** [stream_in row_type table columns] is a shortcut to create a special query
+    that allows multiple rows of type [row_type] to be inserted into the database in an
+    efficient manner (the exact query mechanism depends on the driver used). *)
+
+val stream_out :
+  ?env: (Caqti_driver_info.t -> string -> query) ->
+  ?oneshot: bool ->
+  'row_type Caqti_type.t ->
+  table: string ->
+  columns: string list ->
+  unit ->
+  (counit, counit, 'row_type, [> `Zero | `One | `Many]) t4
+(** [stream_out row_type table columns] is a shortcut to create a special query
+    that allows multiple rows of type [row_type] to be collected from the database in an
+    efficient manner (the exact query mechanism depends on the driver used). *)
 
 val pp : Format.formatter -> ('a, 'b, 'm) t -> unit
 (** [pp ppf req] prints [req] on [ppf] in a form suitable for human

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -28,16 +28,7 @@
     query. *)
 
 (** {2 Primitives} *)
-
-type query =
-  | L of string  (** Literal code. May contain incomplete fragments. *)
-  | P of int     (** [P i] refers to parameter number [i], counting from 0. *)
-  | S of query list (** [S frags] is the concatenation of [frags]. *)
-(** A representation of a query string to send to a database, abstracting over
-    parameter references and providing nested concatenation to simplify
-    generation.  For databases which only support linear parameters (typically
-    denoted "[?]"), the driver will reshuffle, elide, and duplicate parameters
-    as needed.  *)
+type query = Caqti_sql.query
 
 type counit
 (** Empty type *)

--- a/lib/caqti_response_sig.mli
+++ b/lib/caqti_response_sig.mli
@@ -83,6 +83,14 @@ module type S = sig
       Cf. {!fold_s}. *)
 
   val to_stream : ('b, 'm) t -> ('b, [> Caqti_error.retrieve] as 'err) stream
-    (** [to_stream resp] returns a stream whose elements are the decoded rows
-        returned by [resp]. *)
+  (** [to_stream resp] returns a stream whose elements are the decoded rows
+      returned by [resp]. *)
+
+  (** {2 Insertion functions} *)
+
+  val from_stream :
+    (Caqti_request.counit, [`Many_in]) t ->
+    ('row_type, unit) stream ->
+    (unit, [> Caqti_error.driver] as 'err) result future
+  (** [from_stream resp stream] inserts the contents of [stream] into the database. *)
 end

--- a/lib/caqti_sql.ml
+++ b/lib/caqti_sql.ml
@@ -14,6 +14,16 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *)
 
+type query =
+  | L of string
+  | P of int
+  | S of query list
+
+let rec pp_query ppf = function
+ | L s -> Format.pp_print_string ppf s
+ | P n -> Format.pp_print_char ppf '$'; Format.pp_print_int ppf (n + 1)
+ | S qs -> List.iter (pp_query ppf) qs
+
 let bprint_sql_escaped buf s =
   for i = 0 to String.length s - 1 do
     match s.[i] with

--- a/lib/caqti_sql.mli
+++ b/lib/caqti_sql.mli
@@ -14,7 +14,22 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *)
 
-(** SQL utility functions.
+(** {2 SQL Primitives} *)
+
+type query =
+  | L of string  (** Literal code. May contain incomplete fragments. *)
+  | P of int     (** [P i] refers to parameter number [i], counting from 0. *)
+  | S of query list (** [S frags] is the concatenation of [frags]. *)
+(** A representation of a query string to send to a database, abstracting over
+    parameter references and providing nested concatenation to simplify
+    generation.  For databases which only support linear parameters (typically
+    denoted "[?]"), the driver will reshuffle, elide, and duplicate parameters
+    as needed.  *)
+
+val pp_query : Format.formatter -> query -> unit
+(** Pretty-print a query with the supplied formatter (for debugging). *)
+
+(** {2 SQL utility functions}
 
     {b Note.} Since real databases generally do not implement the precise same
     escaping mechanisms, and discrepancies between the escape function and the

--- a/lib/caqti_stream.ml
+++ b/lib/caqti_stream.ml
@@ -43,6 +43,8 @@ module type S = sig
   val to_rev_list : ('a, 'err) t -> ('a list, 'err) result future
 
   val to_list : ('a, 'err) t -> ('a list, 'err) result future
+
+  val from_list : 'a list -> ('a, 'err) t
 end
 
 module type FUTURE = sig
@@ -89,4 +91,9 @@ module Make(X : FUTURE) : S with type 'a future := 'a X.future = struct
   let to_rev_list t = fold ~f:List.cons t []
 
   let to_list t = to_rev_list t >|=? List.rev
+
+  let rec from_list l =
+    fun () -> match l with
+    | [] -> return Nil
+    | hd::tl -> return (Cons (hd, (from_list tl)))
 end

--- a/lib/caqti_stream.mli
+++ b/lib/caqti_stream.mli
@@ -43,6 +43,8 @@ module type S = sig
   val to_rev_list : ('a, 'err) t -> ('a list, 'err) result future
 
   val to_list : ('a, 'err) t -> ('a list, 'err) result future
+
+  val from_list : 'a list -> ('a, 'err) t
 end
 
 module type FUTURE = sig

--- a/tests/test_param.ml
+++ b/tests/test_param.ml
@@ -43,8 +43,8 @@ let test_nonlin (module Db : Caqti_lwt.CONNECTION) =
 
 let env1_q =
   let env _ = function
-   | "." -> Caqti_request.L"100"
-   | "fourty" -> Caqti_request.L"40"
+   | "." -> Caqti_sql.L"100"
+   | "fourty" -> Caqti_sql.L"40"
    | _ -> raise Not_found in
   Caqti_request.find ~env Caqti_type.unit Caqti_type.int "SELECT $. - $(fourty)"
 


### PR DESCRIPTION
This is a (very rough) initial attempt at implementing the interfaces discussed in #26.

Making the attempt at implementing has thrown up a number of issues which need to be thought through. Specifically:

* Keeping backwards compatibility on the `Caqti_request.t` type makes everything more complicated. I think it might be easier to drop that requirement, and then make the next release with these changes in a major release to allow people to cope with the API change. I think this would also be mitigated by making sure that the helper functions do not change - so that only people who have been implementing custom `Caqti_request.t` instances will be affected.
* I think that having the drivers contain the logic for how to build their particular streaming queries makes sense, but I am not happy with the `stream_in_builder` API - is there a better way to do this? Potentially we could extend `Caqti_request.query` to contain an option to have stream data - and then just handle this differently in each driver
* To get the same functionality for `sqlite` the pattern seems to be to just use a prepared insert query in a single transaction - how would that fit in the current `request -> response` model?