### PR TITLE
WIP: Add copy mode (take 2)

### DIFF
--- a/lib-driver/caqti_driver_mariadb.ml
+++ b/lib-driver/caqti_driver_mariadb.ml
@@ -501,6 +501,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
       let values_tuple = "(" ^ (String.concat "," (List.map (fun _ -> "?") columns)) ^ ")" in
       let insert_query =
         Caqti_request.exec
+          ~oneshot:true
           row_type
           ("INSERT INTO " ^ table ^  " " ^ columns_tuple ^ " VALUES " ^ values_tuple)
       in

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -660,6 +660,39 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
     let start () = exec start_req ()
     let commit () = exec commit_req ()
     let rollback () = exec rollback_req ()
+
+    let populate ~table ~columns row_type input_stream =
+      let columns_tuple = "(" ^ (String.concat "," columns) ^ ")" in
+      let values_tuple = "(" ^ (String.concat "," (List.map (fun _ -> "?") columns)) ^ ")" in
+      let insert_query =
+        Caqti_request.exec
+          row_type
+          ("INSERT INTO " ^ table ^  " " ^ columns_tuple ^ " VALUES " ^ values_tuple)
+      in
+      (* TODO: Should we prepare the statement directly somehow? *)
+      begin
+        (* Begin a transaction *)
+        start () >>=? fun () ->
+
+        (* Insert each element in the stream *)
+        System.Stream.iter_s
+          ~f:(fun row -> exec insert_query row)
+          input_stream
+        >>= fun resp ->
+        begin
+          (* Since the input stream cannot contain errors, unpack the combined error type
+           * returned
+           *)
+          match resp with
+          | Ok () as x -> return x
+          | Error (`Callback e) -> return (Error e)
+          | Error (`Self ()) -> failwith "Input stream to populate cannot return errors"
+        end
+        >>=? fun () ->
+
+        (* Commit the transaction *)
+        commit ()
+      end
   end
 
   let connect uri =

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -666,6 +666,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
       let values_tuple = "(" ^ (String.concat "," (List.map (fun _ -> "?") columns)) ^ ")" in
       let insert_query =
         Caqti_request.exec
+          ~oneshot:true
           row_type
           ("INSERT INTO " ^ table ^  " " ^ columns_tuple ^ " VALUES " ^ values_tuple)
       in

--- a/lib-driver/caqti_driver_sqlite3.ml
+++ b/lib-driver/caqti_driver_sqlite3.ml
@@ -476,6 +476,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
       let values_tuple = "(" ^ (String.concat "," (List.map (fun _ -> "?") columns)) ^ ")" in
       let insert_query =
         Caqti_request.exec
+          ~oneshot:true
           row_type
           ("INSERT INTO " ^ table ^  " " ^ columns_tuple ^ " VALUES " ^ values_tuple)
       in

--- a/lib/caqti_connect.ml
+++ b/lib/caqti_connect.ml
@@ -97,6 +97,7 @@ module Make_unix (System : Caqti_driver_sig.System_unix) = struct
       r
 
     let call ~f req param = use (fun () -> C.call ~f req param)
+    let populate ~table ~columns r s = use (fun () -> C.populate ~table ~columns r s)
 
     let exec q p = call ~f:Response.exec q p
     let find q p = call ~f:Response.find q p

--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -67,6 +67,16 @@ module type Base = sig
       during the call to [f], and must not be returned or operated on by other
       threads. *)
 
+  (** {2 Insertion} *)
+  val populate:
+    table: string ->
+    columns: string list ->
+    'input Caqti_type.t ->
+    ('input, unit) stream ->
+    (unit, [> Caqti_error.call_or_retrieve]) result future
+  (** [populate table columns row_type input_stream] inputs the contents of
+      [input_stream] into the database in whatever manner is most efficient
+      as decided by the driver. *)
 
   (** {2 Transactions} *)
 

--- a/lib/caqti_stream.ml
+++ b/lib/caqti_stream.ml
@@ -43,6 +43,8 @@ module type S = sig
   val to_rev_list : ('a, 'err) t -> ('a list, 'err) result future
 
   val to_list : ('a, 'err) t -> ('a list, 'err) result future
+
+  val of_list : 'a list -> ('a, 'err) t
 end
 
 module type FUTURE = sig
@@ -89,4 +91,9 @@ module Make(X : FUTURE) : S with type 'a future := 'a X.future = struct
   let to_rev_list t = fold ~f:List.cons t []
 
   let to_list t = to_rev_list t >|=? List.rev
+
+  let rec of_list l =
+    fun () -> match l with
+    | [] -> return Nil
+    | hd::tl -> return (Cons (hd, (of_list tl)))
 end

--- a/lib/caqti_stream.mli
+++ b/lib/caqti_stream.mli
@@ -30,15 +30,15 @@ module type S = sig
     ('state, 'err) result future
 
   val fold_s :
-    f: ('a -> 'state -> ('state, 'err) result future) ->
+    f: ('a -> 'state -> ('state, 'errc) result future) ->
     ('a, 'err) t ->
     'state ->
-    ('state, 'err) result future
+    ('state, [`Self of 'err| `Callback of 'errc]) result future
 
   val iter_s :
-    f:('a -> (unit, 'err) result future) ->
+    f:('a -> (unit, 'errc) result future) ->
     ('a, 'err) t ->
-    (unit, 'err) result future
+    (unit, [`Self of 'err| `Callback of 'errc]) result future
 
   val to_rev_list : ('a, 'err) t -> ('a list, 'err) result future
 

--- a/lib/caqti_stream.mli
+++ b/lib/caqti_stream.mli
@@ -43,6 +43,8 @@ module type S = sig
   val to_rev_list : ('a, 'err) t -> ('a list, 'err) result future
 
   val to_list : ('a, 'err) t -> ('a list, 'err) result future
+
+  val of_list : 'a list -> ('a, 'err) t
 end
 
 module type FUTURE = sig


### PR DESCRIPTION
This is a second attempt at implementing the copy mode function discussed in #26, but using the new `populate` method discussed in #27. I have created a new MR since this is quite different from the first attempt, and I am happy to either close that MR or just overwrite the branch as preffered.

Implementing in this way is definitely easier, but there are a couple of things I am unhappy with, specifically:

* Due to the way `Caqti_stream.iter_s` is implemented, the error type for the output must match the error type of the input. This doesn't make a lot of sense in the inbound direction, as there are not likely to be any errors in the input stream. Is it worth creating a new `iter` method that allows the input and output error types to be the same?
* I had a lot of trouble getting the compiler to accept the polymorphic variant behaviour for the error types - is there a better way I could handle this? I think it would probably be simpler if I had all the `populate` methods implemented at once (then I could drop the `Not_implemented` error), but then that would mean that other drivers would have to push towards full implementation straight away