### PR TITLE
Postgres populate with copy mode

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -44,7 +44,7 @@
   (name test_sql)
   (wrapped false)
   (modules Test_sql)
-  (libraries caqti ptime.clock.os))
+  (libraries caqti ptime.clock.os testkit))
 
 (test
   (name test_sql_blocking)

--- a/tests/testkit.ml
+++ b/tests/testkit.ml
@@ -50,6 +50,10 @@ let parse_common_args () =
    | Some uri -> [uri]
    | None -> load_uris ())
 
+let init_list n f = (* List.init is available from OCaml 4.6.0 *)
+ let rec loop acc i = if i < 0 then acc else loop (f i :: acc) (i - 1) in
+ loop [] (n - 1)
+
 let () =
   Random.self_init ();
   (* Needed for bytecode since plugins link against C libraries: *)


### PR DESCRIPTION
This PR updates the postgresql driver to use copy mode when the `populate` function is called, which should resolve #26.

The code is still slightly rough, but I can't see any obvious ways to make it clearer at this point - so any suggestions for that would be very welcome.