### PR TITLE
add method exec_count to Caqti_connection_sig.S

### DIFF
--- a/lib/caqti_connection.ml
+++ b/lib/caqti_connection.ml
@@ -55,7 +55,7 @@ struct
     let f resp = Response.fold List.cons resp [] in
     C.call ~f q p
 
-  let exec_count q p =
+  let exec_with_affected_count q p =
     let f response =
       Response.exec response >>= fun execResult ->
       match execResult with

--- a/lib/caqti_connection.ml
+++ b/lib/caqti_connection.ml
@@ -62,7 +62,6 @@ struct
       | Ok () -> Response.affected_count response
       | Error x -> return (Error x) in
     C.call ~f q p
-
 end
 
 module Make_populate

--- a/lib/caqti_connection.ml
+++ b/lib/caqti_connection.ml
@@ -54,6 +54,15 @@ struct
   let rev_collect_list q p =
     let f resp = Response.fold List.cons resp [] in
     C.call ~f q p
+
+  let exec_count q p =
+    let f response =
+      Response.exec response >>= fun execResult ->
+      match execResult with
+      | Ok () -> Response.affected_count response
+      | Error x -> return (Error x) in
+    C.call ~f q p
+
 end
 
 module Make_populate

--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -119,13 +119,12 @@ module type Convenience = sig
   (** Combining {!call} with {!Response.exec}, this sends a request to the
       database and checks that no rows are returned. *)
 
-  val exec_count :
+  val exec_with_affected_count :
     ('a, unit, [< `Zero]) Caqti_request.t -> 'a ->
-    (int, [> Caqti_error.call_or_retrieve | `Unsupported ] as 'e) result future
+    (int, [> Caqti_error.call_or_retrieve ] as 'e) result future
   (** Combining {!call} with {!Response.exec} and {!Response.affected_count},
       this sends a request to the database, checks that no rows are returned and
-      returns the number of affected rows.  Like {!Response.affected_count}, this
-      may not be available for all databases. *)
+      returns the number of affected rows. *)
 
   val find :
     ('a, 'b, [< `One]) Caqti_request.t -> 'a ->

--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -119,6 +119,13 @@ module type Convenience = sig
   (** Combining {!call} with {!Response.exec}, this sends a request to the
       database and checks that no rows are returned. *)
 
+  val exec_count :
+    ('a, unit, [< `Zero]) Caqti_request.t -> 'a ->
+    (int, [> Caqti_error.call_or_retrieve | `Unsupported ] as 'e) result future
+  (** Combining {!call} with {!Response.exec} and {!Response.affected_count},
+      this sends a request to the database, checks that no rows are returned and
+      returns the number of affected rows. *)
+
   val find :
     ('a, 'b, [< `One]) Caqti_request.t -> 'a ->
     ('b, [> Caqti_error.call_or_retrieve] as 'e) result future

--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -124,7 +124,8 @@ module type Convenience = sig
     (int, [> Caqti_error.call_or_retrieve | `Unsupported ] as 'e) result future
   (** Combining {!call} with {!Response.exec} and {!Response.affected_count},
       this sends a request to the database, checks that no rows are returned and
-      returns the number of affected rows. *)
+      returns the number of affected rows.  Like {!Response.affected_count}, this
+      may not be available for all databases. *)
 
   val find :
     ('a, 'b, [< `One]) Caqti_request.t -> 'a ->

--- a/lib/caqti_response_sig.mli
+++ b/lib/caqti_response_sig.mli
@@ -35,9 +35,9 @@ module type S = sig
       function may not be available for all databases. *)
 
   val affected_count :
-    ('b, 'm) t -> (int, [> Caqti_error.retrieve | `Unsupported]) result future
+    ('b, 'm) t -> (int, [> Caqti_error.retrieve ]) result future
   (** [affected_count resp] is the number of rows affected by the updated the
-      produced [resp].  This function may not be available for all databases. *)
+      produced [resp]. *)
 
   (** {2 Result retrieval} *)
 

--- a/tests/test_sql.ml
+++ b/tests/test_sql.ml
@@ -110,7 +110,7 @@ module Q = struct
   let delete_from_tmp = Caqti_request.exec unit
     "DELETE FROM test_sql"
   let select_from_tmp = Caqti_request.collect unit (tup3 int string octets)
-    "SELECT i, s, o FROM test_sql"
+    "SELECT i, s, o FROM test_sql ORDER BY i ASC"
   let select_from_tmp_where_i_lt =
     Caqti_request.collect
       int


### PR DESCRIPTION
This PR adds a convenience method for update and delete statements where one wants to check whether any changes happened to the db.