### PR TITLE
Drop ppx deriving

### DIFF
--- a/caqti.opam
+++ b/caqti.opam
@@ -14,7 +14,6 @@ depends: [
   "dune" {>= "1.11"}
   "logs"
   "ocaml" {>= "4.04.0"}
-  "ppx_deriving"
   "ptime"
   "uri" {>= "1.9.0"}
 ]

--- a/lib/caqti_common_priv.ml
+++ b/lib/caqti_common_priv.ml
@@ -48,6 +48,12 @@ module List = struct
   let rec iter_r f = function
    | [] -> Ok ()
    | x :: xs -> (match f x with Ok () -> iter_r f xs | Error _ as r -> r)
+
+  let rec equal f xs ys =
+    (match xs, ys with
+     | [], [] -> true
+     | x :: xs', y :: ys' -> f x y && equal f xs' ys'
+     | [], _ :: _ | _ :: _, [] -> false)
 end
 
 let finally cleanup thunk =

--- a/lib/caqti_common_priv.mli
+++ b/lib/caqti_common_priv.mli
@@ -42,6 +42,7 @@ module List : sig
   val fold : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
   val fold_r : ('a -> 'b -> ('b, 'e) result) -> 'a list -> 'b -> ('b, 'e) result
   val iter_r : ('a -> (unit, 'e) result) -> 'a list -> (unit, 'e) result
+  val equal : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 end
 
 val finally : (unit -> unit) -> (unit -> 'a) -> 'a

--- a/lib/caqti_query.ml
+++ b/lib/caqti_query.ml
@@ -45,8 +45,17 @@ let rec equal t1 t2 =
   | L s1, L s2 -> String.equal s1 s2
   | Q s1, Q s2 -> String.equal s1 s2
   | P i1, P i2 -> Int.equal i1 i2
-  | S l1, S l2 -> (try List.for_all2 equal l1 l2 with _ -> false)
-  | _ -> false
+  | S l1, S l2 -> 
+    let rec list_equal a b =
+      match (a, b) with
+      | ([], []) -> true
+      | (a::x, b::y) -> equal a b && (list_equal x y)
+      | _ -> false in
+    list_equal l1 l2
+  | L _, _ -> false
+  | Q _, _ -> false
+  | P _, _ -> false
+  | S _, _ -> false
 
 let hash = Hashtbl.hash
 

--- a/lib/caqti_query.ml
+++ b/lib/caqti_query.ml
@@ -19,7 +19,6 @@ type t =
   | Q of string
   | P of int
   | S of t list
-[@@deriving eq]
 
 let normal =
   let rec collect acc = function
@@ -40,6 +39,14 @@ let normal =
      | [] -> S[]
      | [q] -> q
      | qs -> S qs)
+
+let rec equal t1 t2 =
+  match t1, t2 with
+  | L s1, L s2 -> String.equal s1 s2
+  | Q s1, Q s2 -> String.equal s1 s2
+  | P i1, P i2 -> Int.equal i1 i2
+  | S l1, S l2 -> (try List.for_all2 equal l1 l2 with _ -> false)
+  | _ -> false
 
 let hash = Hashtbl.hash
 

--- a/lib/caqti_query.ml
+++ b/lib/caqti_query.ml
@@ -14,6 +14,8 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *)
 
+open Caqti_common_priv
+
 type t =
   | L of string
   | Q of string
@@ -45,13 +47,7 @@ let rec equal t1 t2 =
   | L s1, L s2 -> String.equal s1 s2
   | Q s1, Q s2 -> String.equal s1 s2
   | P i1, P i2 -> Int.equal i1 i2
-  | S l1, S l2 -> 
-    let rec list_equal a b =
-      match (a, b) with
-      | ([], []) -> true
-      | (a::x, b::y) -> equal a b && (list_equal x y)
-      | _ -> false in
-    list_equal l1 l2
+  | S ts1, S ts2 -> List.equal equal ts1 ts2
   | L _, _ -> false
   | Q _, _ -> false
   | P _, _ -> false

--- a/lib/dune
+++ b/lib/dune
@@ -38,8 +38,7 @@
   (private_modules
     Caqti_compat)
   (library_flags (:standard -linkall))
-  (libraries logs ptime uri)
-  (preprocess (pps ppx_deriving.eq)))
+  (libraries logs ptime uri))
 
 (rule
   (target caqti_compat.ml)


### PR DESCRIPTION
Fixes #49

This is the code that the ppx generates:
```ocaml
let rec equal : t -> t -> Ppx_deriving_runtime.bool =
  let __0 () = equal in
  ((let open! ((Ppx_deriving_runtime)[@ocaml.warning "-A"]) in
      fun lhs ->
        fun rhs ->
          match (lhs, rhs) with
          | (L lhs0, L rhs0) ->
              ((fun (a : string) -> fun b -> a = b)) lhs0 rhs0
          | (Q lhs0, Q rhs0) ->
              ((fun (a : string) -> fun b -> a = b)) lhs0 rhs0
          | (P lhs0, P rhs0) -> ((fun (a : int) -> fun b -> a = b)) lhs0 rhs0
          | (S lhs0, S rhs0) ->
              (let rec loop x y =
                 match (x, y) with
                 | ([], []) -> true
                 | (a::x, b::y) -> ((fun x -> (__0 ()) x) a b) && (loop x y)
                 | _ -> false in
               (fun x -> fun y -> loop x y)) lhs0 rhs0
          | _ -> false)
    [@ocaml.warning "-A"])[@@ocaml.warning "-39"]
```