### PR TITLE
Ford Prefect misspelling

### DIFF
--- a/tests/bikereg.ml
+++ b/tests/bikereg.ml
@@ -120,7 +120,7 @@ let test db =
   (* Examples of statement execution: Create and populate the register. *)
   create_bikereg db >>=? fun () ->
   reg_bike db "BIKE-0000" "Arthur Dent" >>=? fun () ->
-  reg_bike db "BIKE-0001" "Ford Perfect" >>=? fun () ->
+  reg_bike db "BIKE-0001" "Ford Prefect" >>=? fun () ->
   reg_bike db "BIKE-0002" "Zaphod Beeblebrox" >>=? fun () ->
   reg_bike db "BIKE-0003" "Trillian" >>=? fun () ->
   reg_bike db "BIKE-0004" "Marvin" >>=? fun () ->


### PR DESCRIPTION
This fixes the small misspeling of [Ford Prefect](https://en.wikipedia.org/wiki/Ford_Prefect_(character))'s name. :-)