### PR TITLE
Relax version constraints on Jane Street packages

### DIFF
--- a/caqti-async.opam
+++ b/caqti-async.opam
@@ -8,12 +8,12 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml"
-  "async_kernel" {>= "v0.11.0" & < "v0.14.0~"}
-  "async_unix" {>= "v0.11.0" & < "v0.14.0~"}
+  "async_kernel" {>= "v0.11.0" & < "v0.15.0~"}
+  "async_unix" {>= "v0.11.0" & < "v0.15.0~"}
   "caqti" {>= "1.3.0" & < "1.4.0~"}
   "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
-  "core_kernel" {< "v0.14.0~"}
+  "core_kernel" {< "v0.15.0~"}
   "dune" {>= "1.11"}
 ]
 build: [


### PR DESCRIPTION
caqti-async appears to compile fine with version 0.14 of Jane Street packages.  Not sure why the version constraint was tightened since the previous version (1.2.2).