### PR TITLE
Fix various documentation typos and formatting

### DIFF
--- a/lib-driver/caqti_driver_mariadb.mli
+++ b/lib-driver/caqti_driver_mariadb.mli
@@ -16,10 +16,10 @@
 
 (** Caqti driver for MariaDB (bindings).
 
-    This driver is implement in terms of the mariadb OPAM package.
+    This driver is implemented in terms of the mariadb OPAM package.
     It handles URIs of the form
-
-      {[mariadb://<user>:<password>@<host>:<port>/?socket=<socket>]}
-
+    {[
+      mariadb://<user>:<password>@<host>:<port>/?socket=<socket>
+    ]}
     where components are optional and present ones are passed on to the
     correspondingly named arguments to the [connect] function of MariaDB. *)

--- a/lib-driver/caqti_driver_postgresql.mli
+++ b/lib-driver/caqti_driver_postgresql.mli
@@ -16,15 +16,15 @@
 
 (** PostgreSQL driver for Caqti (bindings).
 
-    This driver is implemented in terms of the postgrsql OPAM package which
+    This driver is implemented in terms of the postgresql OPAM package which
     provides bindings for the PostgreSQL C client library.
 
     It handles URIs of the form
-
-      {[postgresql://<user>:<password>@<host>:<port>/<rest>]}
-
+    {[
+      postgresql://<user>:<password>@<host>:<port>/<rest>
+    ]}
     which are passed verbatim to {!Postgresql.connection}, and URIs of the form
-    [postgresq:/<query>] which are first split into [<key> = '<value>'] form.
+    [postgresql://<query>] which are first split into [<key> = '<value>'] form.
 
     Additionally the query option [notice_processing] can be set to [quiet] (the
     default) to suppress notices or to [stderr] to emit notices to standard

--- a/lib-driver/caqti_driver_sqlite3.mli
+++ b/lib-driver/caqti_driver_sqlite3.mli
@@ -16,11 +16,11 @@
 
 (** Sqlite3 driver for Caqti (bindings).
 
-    This driver is implemeted in terms of the sqlite3 OPAM package, which
+    This driver is implemented in terms of the sqlite3 OPAM package, which
     provides bindings for libsqlite3.  It handles URIs of the form
-
-      {[sqlite3:/<path>?create=<bool>&write=<bool>]}
-
+    {[
+      sqlite3://<path>?create=<bool>&write=<bool>
+    ]}
     where [<path>] is passed to {!Sqlite3.db_open} and the query string is used
     to determine its [mode] parameter.  The [<bool>] parameters take the values
     [true] and [false], and default to [true]. *)

--- a/lib/caqti_common_priv.mli
+++ b/lib/caqti_common_priv.mli
@@ -16,7 +16,7 @@
 
 (** {b Internal:} Prerequisites.
 
-    This module is ment for internal use by Caqti and may change in backwards
+    This module is meant for internal use by Caqti and may change in backwards
     incompatible ways between minor versions without prior notice. *)
 
 val (%) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c

--- a/lib/caqti_connection_sig.mli
+++ b/lib/caqti_connection_sig.mli
@@ -180,7 +180,7 @@ module type Convenience = sig
     ('b list, [> Caqti_error.call_or_retrieve] as 'e) result future
   (** [rev_collect_list request param] performs a {!call} on [request],
       extracting the result as a reversed list.  This is more efficient than
-      {!find_list} and fits well with a subsequent {!List.rev_map}, though it
+      {!collect_list} and fits well with a subsequent {!List.rev_map}, though it
       may not matter much in practise. *)
 end
 

--- a/lib/caqti_driver_info.mli
+++ b/lib/caqti_driver_info.mli
@@ -64,7 +64,7 @@ val uri_scheme : t -> string
 val dialect_tag : t -> dialect_tag
 (** A variant indicating the SQL dialect or other query language, used for easy
     dispatching when constructing queries.  Can be omitted if non of the cases
-    applies, but this means clients must inspect the backend-info to indentify
+    applies, but this means clients must inspect the backend-info to identify
     the language. *)
 
 val parameter_style : t -> parameter_style

--- a/lib/caqti_error.mli
+++ b/lib/caqti_error.mli
@@ -20,7 +20,7 @@
 (** {2 Messages} *)
 
 type msg = ..
-(** In this type, drivers can stash information about an errors in ther own
+(** In this type, drivers can stash information about any errors in their own
     format, which can later be used for pretty-printing and or future
     operations. Drivers must {!define_msg} on each constructor added to this
     type. *)

--- a/lib/caqti_request.mli
+++ b/lib/caqti_request.mli
@@ -23,9 +23,8 @@
     database connection handle.
 
     The request often represent a prepared query, in which case it is static and
-    can be be defined directly in a module scope.  However, an optional
-    [oneshot] parameter may be passed to indicate a dynamically generated
-    query. *)
+    can be defined directly in a module scope.  However, an optional [oneshot]
+    parameter may be passed to indicate a dynamically generated query. *)
 
 (** {2 Primitives} *)
 
@@ -198,18 +197,18 @@ val pp_with_param :
     following can be used to existentially pack the parameter types along with
     the corresponding parameter values to allow collecing them incrementally:
     {[
-module Dynparam = struct
-  type t = Pack : 'a Caqti_type.t * 'a -> t
-  let empty = Pack (Caqti_type.unit, ())
-  let add t x (Pack (t', x')) = Pack (Caqti_type.tup2 t' t, (x', x))
-end
+      module Dynparam = struct
+        type t = Pack : 'a Caqti_type.t * 'a -> t
+        let empty = Pack (Caqti_type.unit, ())
+        let add t x (Pack (t', x')) = Pack (Caqti_type.tup2 t' t, (x', x))
+      end
     ]}
     Now, given a [param : Dynparam.t] and a corresponding query string [qs], one
     can construct a request and execute it:
     {[
-let Dynparam.Pack (pt, pv) = param in
-let req = Caqti_request.exec ~oneshot:true pt qs in
-C.exec req pv
+      let Dynparam.Pack (pt, pv) = param in
+      let req = Caqti_request.exec ~oneshot:true pt qs in
+      C.exec req pv
     ]}
     Note that dynamically constructed requests should have [~oneshot:true]
     unless they are memoized.  Also note that it is natural to use {!create} for

--- a/lib/caqti_type_sig.mli
+++ b/lib/caqti_type_sig.mli
@@ -29,9 +29,9 @@ module type Std = sig
   val option : 'a t -> 'a option t
 
   val unit : unit t
-  (** A holding no fields. This is used to pass no parameters and as the result
-      for queries which does not return any rows. It can also be nested in
-      tuples, in which case it will not contribute to the total number of
+  (** A type holding no fields. This is used to pass no parameters and as the
+      result for queries which does not return any rows. It can also be nested
+      in tuples, in which case it will not contribute to the total number of
       fields. *)
 
   val tup2 : 'a t -> 'b t -> ('a * 'b) t


### PR DESCRIPTION
Just a drive-by fix of some typos and dead links that I stumbled across.  No guarantee of exhaustiveness :)