### PR TITLE
Add Caqti_connect_sig.S.with_connection

### DIFF
--- a/lib/caqti_connect.ml
+++ b/lib/caqti_connect.ml
@@ -90,6 +90,13 @@ module Make_unix (System : Caqti_driver_sig.System_unix) = struct
      | Error err ->
         return (Error err))
 
+  let with_connection uri f =
+    connect uri >>=? fun ((module Db) as conn) ->
+    try
+      f conn >>= fun result -> Db.disconnect () >|= fun () -> result
+    with exn ->
+      Db.disconnect () >|= fun () -> raise exn
+
   module Pool = Caqti_pool.Make (System)
   module Stream = System.Stream
 

--- a/lib/caqti_connect_sig.mli
+++ b/lib/caqti_connect_sig.mli
@@ -43,6 +43,11 @@ module type S = sig
       If you use preemptive threading, note that the connection must only be
       used from the thread where it was created. *)
 
+  val with_connection :
+    Uri.t ->
+    (connection -> ('a, [> Caqti_error.load_or_connect] as 'e) result future) ->
+      ('a, 'e) result future
+
   val connect_pool :
     ?max_size: int -> ?max_idle_size: int ->
     ?post_connect: (connection -> (unit, 'connect_error) result future) ->

--- a/lib/caqti_connect_sig.mli
+++ b/lib/caqti_connect_sig.mli
@@ -47,6 +47,10 @@ module type S = sig
     Uri.t ->
     (connection -> ('a, [> Caqti_error.load_or_connect] as 'e) result future) ->
       ('a, 'e) result future
+  (** [with_connection uri f] calls {!connect} on [uri]. If {!connect} evaluates
+      to [Ok connection], [with_connection] passes the connection to [f]. Once
+      [f] either evaluates to a [result], or raises an exception,
+      [with_connection] closes the database connection. *)
 
   val connect_pool :
     ?max_size: int -> ?max_idle_size: int ->

--- a/tests/bikereg.ml
+++ b/tests/bikereg.ml
@@ -144,6 +144,6 @@ let report_error = function
 
 let () = Lwt_main.run begin
   Lwt_list.iter_s
-    (fun uri -> Caqti_lwt.connect uri >>=? test >>= report_error)
+    (fun uri -> Caqti_lwt.with_connection uri test >>= report_error)
     (Testkit.parse_common_args ())
 end


### PR DESCRIPTION
I'd like to have this for some subcommands of my app that just need one connection briefly to do their work.

Using only `connect` requires adding cleanup in two branches, exception and normal completion (or does it? the tests don't clean up &mdash; still, I think it's better and more future-proof to call `disconnect`). Using a pool would require adding code at the end to drain the pool, to get the same effect. So neither `connect` alone nor a pool give a nice way to run just a few operations quickly.

The signature of the callback is the same as in `Pool.use`, but with the errors from `CONNECTION.connect`.

I "added" `with_connection` to the tests by modifying `tests/bikereg.ml` to use it.