### PR TITLE
Add Caqti_lwt.with_connection_or_fail

### DIFF
--- a/lib-lwt/caqti_lwt.ml
+++ b/lib-lwt/caqti_lwt.ml
@@ -78,3 +78,7 @@ include Caqti_connect.Make_unix (System)
 let or_fail = function
  | Ok x -> Lwt.return x
  | Error (#Caqti_error.t as err) -> Lwt.fail (Caqti_error.Exn err)
+
+let with_connection_or_fail uri f =
+  let open Lwt.Infix in
+  with_connection uri (fun conn -> f conn >|= fun x -> Ok x) >>= or_fail

--- a/lib-lwt/caqti_lwt.mli
+++ b/lib-lwt/caqti_lwt.mli
@@ -24,3 +24,7 @@ include Caqti_connect_sig.S with type 'a future := 'a Lwt.t
 val or_fail : ('a, [< Caqti_error.t]) result -> 'a Lwt.t
 (** Converts an error to an Lwt future failed with a {!Caqti_error.Exn}
     exception holding the error. *)
+
+val with_connection_or_fail : Uri.t -> (connection -> 'a Lwt.t) -> 'a Lwt.t
+(** Calls {!with_connection}, and composes both the callback and the result with
+    {!or_fail}. *)


### PR DESCRIPTION
As the docstring says, this is an Lwt-friendly version of `with_connection`, which I end up defining in my code.

I want to do the same for `Caqti_lwt.Pool.use` &mdash; I also define an Lwt-version of it in my code. This seems to require some module gymnastics, however. Looking into that next.