### PR TITLE
Add enum field type.

### DIFF
--- a/lib-driver/caqti_driver_mariadb.ml
+++ b/lib-driver/caqti_driver_mariadb.ml
@@ -140,6 +140,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
      | Caqti_type.Int64 -> Ok (`Int (Int64.to_int x))
      | Caqti_type.Float -> Ok (`Float x)
      | Caqti_type.String -> Ok (`String x)
+     | Caqti_type.Enum _ -> Ok (`String x)
      | Caqti_type.Octets -> Ok (`Bytes (Bytes.of_string x))
      | Caqti_type.Pdate ->
         let year, month, day = Ptime.to_date x in
@@ -177,6 +178,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
      | Caqti_type.Int64 -> Ok (Mdb_ext.Field.int64 field)
      | Caqti_type.Float -> Ok (Mdb.Field.float field)
      | Caqti_type.String -> Ok (Mdb_ext.Field.string field)
+     | Caqti_type.Enum _ -> Ok (Mdb_ext.Field.string field)
      | Caqti_type.Octets -> Ok (Mdb_ext.Field.string field)
      | Caqti_type.Pdate ->
         let t = Mdb.Field.time field in

--- a/lib-driver/caqti_driver_postgresql.ml
+++ b/lib-driver/caqti_driver_postgresql.ml
@@ -176,6 +176,7 @@ module Pg_ext = struct
       Error "Non-integer days in interval string."
 end
 
+let unknown_oid = Pg.oid_of_ftype Pg.UNKNOWN
 let bool_oid = Pg.oid_of_ftype Pg.BOOL
 let int2_oid = Pg.oid_of_ftype Pg.INT2
 let int4_oid = Pg.oid_of_ftype Pg.INT4
@@ -200,6 +201,7 @@ let init_param_types ~uri =
    | Caqti_type.Pdate -> Ok date_oid
    | Caqti_type.Ptime -> Ok timestamp_oid
    | Caqti_type.Ptime_span -> Ok interval_oid
+   | Caqti_type.Enum _ -> Ok unknown_oid
    | field_type ->
       (match Caqti_type.Field.coding driver_info field_type with
        | None ->
@@ -253,6 +255,7 @@ module Make_encoder (String_encoder : STRING_ENCODER) = struct
      | Caqti_type.Int64 -> Ok (Int64.to_string x)
      | Caqti_type.Float -> Ok (sprintf "%.17g" x)
      | Caqti_type.String -> Ok (encode_string x)
+     | Caqti_type.Enum _ -> Ok (encode_string x)
      | Caqti_type.Octets -> Ok (encode_octets x)
      | Caqti_type.Pdate -> Ok (iso8601_of_pdate x)
      | Caqti_type.Ptime ->
@@ -330,6 +333,7 @@ let rec decode_field
    | Caqti_type.Int64 -> conv Int64.of_string s
    | Caqti_type.Float -> conv float_of_string s
    | Caqti_type.String -> Ok s
+   | Caqti_type.Enum _ -> Ok s
    | Caqti_type.Octets -> Ok (Postgresql.unescape_bytea s)
    | Caqti_type.Pdate ->
       (match pdate_of_iso8601 s with

--- a/lib-driver/caqti_driver_sqlite3.ml
+++ b/lib-driver/caqti_driver_sqlite3.ml
@@ -65,6 +65,7 @@ let rec data_of_value
    | Caqti_type.Int64  -> Ok (Sqlite3.Data.INT x)
    | Caqti_type.Float  -> Ok (Sqlite3.Data.FLOAT x)
    | Caqti_type.String -> Ok (Sqlite3.Data.TEXT x)
+   | Caqti_type.Enum _ -> Ok (Sqlite3.Data.TEXT x)
    | Caqti_type.Octets -> Ok (Sqlite3.Data.BLOB x)
    | Caqti_type.Pdate -> Ok (Sqlite3.Data.TEXT (iso8601_of_pdate x))
    | Caqti_type.Ptime ->
@@ -107,6 +108,7 @@ let rec value_of_data
    | Caqti_type.Float, Sqlite3.Data.FLOAT y -> Ok y
    | Caqti_type.Float, Sqlite3.Data.INT y -> Ok (Int64.to_float y)
    | Caqti_type.String, Sqlite3.Data.TEXT y -> Ok y
+   | Caqti_type.Enum _, Sqlite3.Data.TEXT y -> Ok y
    | Caqti_type.Octets, Sqlite3.Data.BLOB y -> Ok y
    | Caqti_type.Pdate as field_type, Sqlite3.Data.TEXT y ->
       (match pdate_of_iso8601 y with

--- a/lib/caqti_type.ml
+++ b/lib/caqti_type.ml
@@ -30,6 +30,7 @@ type _ field +=
   | Pdate : Ptime.t field
   | Ptime : Ptime.t field
   | Ptime_span : Ptime.span field
+  | Enum : string -> string field
 
 module Field = struct
 
@@ -67,6 +68,7 @@ module Field = struct
    | Pdate -> "pdate"
    | Ptime -> "ptime"
    | Ptime_span -> "ptime_span"
+   | Enum name -> name
    | ft -> Obj.Extension_constructor.name (Obj.Extension_constructor.of_val ft)
 
   let pp_ptime = Ptime.pp_rfc3339 ~tz_offset_s:0 ~space:false ()
@@ -85,6 +87,7 @@ module Field = struct
       Format.fprintf ppf "%d-%02d-%02d" y m d
    | Ptime, x -> pp_ptime ppf x
    | Ptime_span, x -> Ptime.Span.pp ppf x
+   | Enum _, x -> Format.pp_print_string ppf x
    | ft ->
       Format.fprintf ppf "<%s>"
         (Obj.Extension_constructor.name (Obj.Extension_constructor.of_val ft))
@@ -203,6 +206,8 @@ module Std = struct
   let tup3 t0 t1 t2 = Tup3 (t0, t1, t2)
   let tup4 t0 t1 t2 t3 = Tup4 (t0, t1, t2, t3)
   let custom ~encode ~decode rep = Custom {rep; encode; decode}
+  let enum ~encode ~decode name =
+    Custom {rep = Field (Enum name); encode = (fun x -> Ok (encode x)); decode}
 
   let bool = Field Bool
   let int = Field Int

--- a/lib/caqti_type.mli
+++ b/lib/caqti_type.mli
@@ -41,6 +41,7 @@ type _ field +=
   | Pdate : Ptime.t field
   | Ptime : Ptime.t field
   | Ptime_span : Ptime.span field
+  | Enum : string -> string field
 
 (** Facilities for extending and using primitive field types. *)
 module Field : sig

--- a/lib/caqti_type_sig.mli
+++ b/lib/caqti_type_sig.mli
@@ -96,4 +96,13 @@ module type Std = sig
   val ptime_span : Ptime.span t
   (** A period of time. If the database lacks a dedicated representation, the
       integer number of seconds is used. *)
+
+  val enum :
+    encode: ('a -> string) ->
+    decode: (string -> ('a, string) result) ->
+    string -> 'a t
+  (** [enum ~encode ~decode name] creates an enum type which on the SQL side is
+      named [name], with cases which are converted with [encode] and [decode]
+      functions. This is implemented in terms of the {!Caqti_type.Enum} field
+      type. *)
 end

--- a/tests/test_sql.ml
+++ b/tests/test_sql.ml
@@ -67,7 +67,7 @@ module Q = struct
   let create_type_abc = (unit -->! unit) @@ fun _ ->
     "CREATE TYPE abc AS ENUM ('aye', 'bee', 'cee')"
   let drop_type_abc = (unit -->! unit) @@ fun _ ->
-    "DROP TYPE abc"
+    "DROP TYPE IF EXISTS abc"
   let create_table_test_abc = (unit -->! unit) @@ function
    | `Pgsql ->
       "CREATE TEMPORARY TABLE test_abc (e abc PRIMARY KEY, s char(3) NOT NULL)"
@@ -358,6 +358,7 @@ struct
       (match Caqti_driver_info.dialect_tag Db.driver_info with
        | `Sqlite | `Mysql -> f ()
        | _ ->
+          Db.exec Q.drop_type_abc () >>=? fun () ->
           Db.exec Q.create_type_abc () >>=? fun () ->
           f () >>=? fun () ->
           Db.exec Q.drop_type_abc ())


### PR DESCRIPTION
This is a possible solution to #64. The enum is merely declared "unknown" to PostgreSQL, which I presume corresponds the old behaviour when no types where passed. (It might also be possible to query the `pg_type` table to acquire the correct OID of enum types, just in time before sending the actual query.)