### PR TITLE
Disallow ?i non-linear substitutions

### DIFF
--- a/caqti/lib/caqti_request.ml
+++ b/caqti/lib/caqti_request.ml
@@ -93,7 +93,10 @@ let format_query ~env qs =
      | '?' ->
         if p < 0 then invalid_arg "Mixed ? and $i style parameters." else
         let acc = L (String.sub qs i (j - i)) :: acc in
-        loop (p + 1) (j + 1) (j + 1) (P p :: acc)
+        if j + 1 < n && (match qs.[j+1] with '0'..'9' -> true | _ -> false) then
+          invalid_arg "?i is not allowed"
+        else
+          loop (p + 1) (j + 1) (j + 1) (P p :: acc)
      | '$' ->
         if j + 1 = n then invalid_arg "$ at end of query" else
         let acc = L (String.sub qs i (j - i)) :: acc in


### PR DESCRIPTION
In the discussion for PR #77 @paurkedal brought up that caqti offers a
choice between `?` and `$n`. In practice, it was possible to use `?n`
with the sqlite3 driver as long as the number of substitutions
corresponds to the number of arguments. The following query would work:

    SELECT * FROM house WHERE color = ?2 AND city = ?1

while the following would fail:

    SELECT * FROM house WHERE color = ?2 AND (?1 IS NULL OR city = ?1)