### PR TITLE
CHANGES.md: sqlite3 foreign constraints tweak ver.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ New features:
     database systems.
 
   - Enable foreign key constraint checks for SQLite3 starting at tweaks
-    version 1.7.
+    version 1.8.
 
 Fixes:
 


### PR DESCRIPTION
Sqlite3 foreign key constraint checks starts from tweaks version 1.8 and not 1.7 as far as I can read from the code.