### PR TITLE
Update README from deprecated function, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ the needed database driver.  E.g.
 module Db : Caqti_lwt.CONNECTION
 
 (* Create a request which merely adds two parameters. *)
-# let plus = Caqti_request.find Caqti_type.(tup2 int int) Caqti_type.int "SELECT ? + ?";;
+# let plus = Caqti_request.(Caqti_type.(tup2 int int) ->! Caqti_type.int) "SELECT ? + ?";;
 val plus : (int * int, int, [< `Many | `One | `Zero > `One ]) Caqti_request.t =
   <abstr>
 

--- a/caqti/lib/caqti_request.mli
+++ b/caqti/lib/caqti_request.mli
@@ -176,7 +176,7 @@ module Infix : sig
     'a Caqti_type.t -> unit Caqti_type.t ->
     ?oneshot: bool -> string -> ('a, unit, [`Zero]) t
   (** [(pt ->. Caqti_type.unit) ?oneshot s] is the request which sends the
-      equery string [s], encodes parameters according to [pt], and expects no
+      query string [s], encodes parameters according to [pt], and expects no
       result rows. See {!create} for the meaning of [oneshot]. *)
 
   val ( ->! ) :


### PR DESCRIPTION
I'm not sure if this change to the README is less clear, but it avoids the now deprecated function `Caqti_request.find`. It also removes a spurious 'e' in Caqti_request.mli.