### PR TITLE
sqlite3-driver: rename prepare to prepare_db

### DIFF
--- a/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml
+++ b/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml
@@ -543,7 +543,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
     let set_statement_timeout _ = return (Ok ())
   end
 
-  let prepare_db ~tweaks_version db =
+  let setup ~tweaks_version db =
     if tweaks_version < (1, 8) then return () else
     Preemptive.detach (Sqlite3.exec db) "PRAGMA foreign_keys = ON"
       >>= fun rc ->
@@ -571,7 +571,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
         (fun () ->
           Sqlite3.db_open ~mutex:`FULL ?mode (Uri.path uri |> Uri.pct_decode))
         () >>= fun db ->
-      prepare_db ~tweaks_version db >|= fun () ->
+      setup ~tweaks_version db >|= fun () ->
       (match busy_timeout with
        | None -> ()
        | Some timeout -> Sqlite3.busy_timeout db timeout);

--- a/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml
+++ b/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml
@@ -543,7 +543,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
     let set_statement_timeout _ = return (Ok ())
   end
 
-  let prepare ~tweaks_version db =
+  let prepare_db ~tweaks_version db =
     if tweaks_version < (1, 8) then return () else
     Preemptive.detach (Sqlite3.exec db) "PRAGMA foreign_keys = ON"
       >>= fun rc ->
@@ -571,7 +571,7 @@ module Connect_functor (System : Caqti_driver_sig.System_unix) = struct
         (fun () ->
           Sqlite3.db_open ~mutex:`FULL ?mode (Uri.path uri |> Uri.pct_decode))
         () >>= fun db ->
-      prepare ~tweaks_version db >|= fun () ->
+      prepare_db ~tweaks_version db >|= fun () ->
       (match busy_timeout with
        | None -> ()
        | Some timeout -> Sqlite3.busy_timeout db timeout);


### PR DESCRIPTION
In the same file there's another function called [prepare]. While the scopes do not overlap it can be a little confusing when using simple search in the file. I was reading the file and searching for the definition of prepare with simple search and I was surprised to see `PRAGMA foreign_keys = ON` was done each time.