### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/caqti/lib/dune
+++ b/caqti/lib/dune
@@ -38,7 +38,7 @@
   (private_modules
     Caqti_compat)
   (library_flags (:standard -linkall))
-  (libraries angstrom bigstringaf logs ptime uri))
+  (libraries angstrom bigstringaf logs ptime uri unix))
 
 (rule
   (target caqti_compat.ml)


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.