### PR TITLE
Add a printf-like `Caqti_query.qprintf` for dynamic queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ New features:
     resources from pools which have been unused for the given period.
 
   - Printf-style function `Caqti_query.qprintf` for dynamic queries
+    (GPR#103, Basile Clément).
 
 Breaking changes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ New features:
   - A new pool connection parameter `?max_idle_age` provides removal
     resources from pools which have been unused for the given period.
 
+  - Printf-style function `Caqti_query.qprintf` for dynamic queries
+
 Breaking changes:
 
   - The minimal OCaml requirement is now 4.08.0.

--- a/caqti.opam
+++ b/caqti.opam
@@ -4,6 +4,7 @@ maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
 authors: [
   "Petter A. Urkedal <paurkedal@gmail.com>"
   "Nathan Rebours <nathan@cryptosense.com>"
+  "Basile Clément"
 ]
 license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 homepage: "https://github.com/paurkedal/ocaml-caqti/"

--- a/caqti/lib/caqti_query.ml
+++ b/caqti/lib/caqti_query.ml
@@ -283,3 +283,136 @@ let of_string_exn s =
    | Ok q -> q
    | Error (`Invalid (pos, msg)) ->
       Printf.ksprintf failwith "Parse error at byte %d: %s" pos msg)
+
+(* Printf-like helpers *)
+
+type Format.stag += Stag_query of t
+
+let query ppf q =
+  Format.pp_open_stag ppf (Stag_query q);
+  Format.pp_print_string ppf "... SQL FRAGMENT ...";
+  Format.pp_close_stag ppf ()
+
+let quote ppf q = query ppf (Q q)
+let env ppf e = query ppf (E e)
+let param ppf p = query ppf (P p)
+
+type mode = Mode_literal | Mode_ignore | Mode_raw of (string -> t)
+
+let kqprintf k fmt =
+  (* The formatter can be in three different modes, which is determined
+     depending on the currently open tags (we exploit the fact that
+     [mark_open_stag] and [mark_close_tag] are called immediately before the tag
+     would actually be output to the formatter, and so can we can effectively
+     use them as control directives for the behavior of [output_string]).
+
+     Internally, the formatter holds a list of query elements in the reverse
+     order that they have been produced in. Once we have finished parsing, that
+     list is reversed, wrapped into the [S] constructor, and returned. We will
+     call this list of elements we are building "the queue" in the following.
+
+     Initially, the formatter starts in literal mode. In literal mode, we simply
+     push each string that we receive from the formatter into the queue
+     unmodified as a literal.
+
+     When we encounter a tag in literal mode, we enter one of two auxiliary
+     modes:
+
+      - If the tag is the string tag "Q" or "E" (denoting a nested quote or env
+        var format, respectively), we enter raw mode, parameterized by a
+        function that returns either [Q] or [E]. In raw mode, we accumulate the
+        content that gets printed into a buffer, and when exiting raw mode
+        (i.e. when the corresponding tag gets closed), we wrap the accumulated
+        content as a string into either the [Q] or [E] constructor, and push it
+        into the queue. Then, we exit go back to literal mode.
+
+      - If the tag is custom tag [Stag_query], added by the {!query} printer, we
+        push the embedded query without modifications onto the queue, then
+        switch to ignore mode. In ignore mode, we simply discard what is printed
+        until we exit ignore mode by closing the corresponding tag. This is
+        because, in ignore mode, the content that we are interested in is the
+        parameter of the [Stag_query], not the textual content within the tag.
+
+     Nesting of tags is not supported, so if we see one of the tags above in
+     either of these modes, we raise a [Failure] exception.
+  *)
+  let elems = ref [] in
+  let buf = Buffer.create 512 in
+
+  let push q = elems := q :: !elems in
+  let mode = ref Mode_literal in
+  let flush_raw () =
+    let mk = match !mode with Mode_raw f -> f | _ -> assert false in
+    push @@ mk @@ Buffer.contents buf;
+    Buffer.reset buf;
+    mode := Mode_literal
+  and flush_ignore () =
+    match !mode with Mode_ignore -> mode := Mode_literal | _ -> assert false
+  and flush_literal () =
+    (* Unlike the similar cases in [flush_raw] and [flush_ignore], it is actually
+       possible to call [flush_literal] while not in literal mode by nesting <Q>
+       and/or <E> semantic tags.
+
+       There is actually nothing to do here, because we push output strings into
+       the queue on the fly. *)
+    begin
+      match !mode with
+      | Mode_literal -> ()
+      | _ -> failwith "invalid nesting of query tags; did you forget a `@}`?"
+    end
+  and output_string s p n =
+    match !mode with
+    | Mode_literal ->
+      if n > 0 then
+        if p = 0 && n = String.length s then
+          push (L s)
+        else
+          push (L (String.sub s p n))
+    | Mode_raw _ -> Buffer.add_substring buf s p n
+    | Mode_ignore -> ()
+  in
+  let ppf = Format.make_formatter output_string flush_literal in
+  let Format.
+        { mark_open_stag; mark_close_stag; print_open_stag; print_close_stag } =
+    Format.pp_get_formatter_stag_functions ppf ()
+  in
+  (* Note that we call [flush_literal] when *opening* tags but the other [flush]
+     functions when *closing* tags.  Since [Format] enforces the
+     well-parenthesising of tags, we are guaranteed to always be in the correct
+     mode when calling [flush_raw] and [flush_ignore], but that is *not* the
+     case for [flush_litera].
+  *)
+  let mark_open_stag = function
+    | Format.String_tag "Q" ->
+        flush_literal ();
+        mode := Mode_raw (fun s -> Q s);
+        ""
+    | Format.String_tag "E" ->
+        flush_literal ();
+        mode := Mode_raw (fun s -> E s);
+        ""
+    | Stag_query q ->
+        flush_literal ();
+        push q;
+        mode := Mode_ignore;
+        ""
+    | t -> mark_open_stag t
+  and mark_close_stag = function
+    | Format.String_tag ("Q" | "E") ->
+        flush_raw ();
+        ""
+    | Stag_query _ ->
+        flush_ignore ();
+        ""
+    | t -> mark_close_stag t
+  in
+  Format.pp_set_formatter_stag_functions ppf
+    { mark_open_stag; mark_close_stag; print_open_stag; print_close_stag };
+  Format.pp_set_mark_tags ppf true;
+  Format.kfprintf
+    (fun ppf ->
+      Format.pp_print_flush ppf ();
+      k (S (List.rev !elems)))
+    ppf fmt
+
+let qprintf fmt = kqprintf Fun.id fmt

--- a/caqti/lib/caqti_query.mli
+++ b/caqti/lib/caqti_query.mli
@@ -107,3 +107,69 @@ val of_string_exn : string -> t
 (** Like {!of_string}, but raises an exception on error.
 
     @raise Failure if parsing failed. *)
+
+val qprintf : ('a, Format.formatter, unit, t) format4 -> 'a
+(** {!qprintf} allows building Caqti queries using a printf-style interface.
+
+  When using {!qprintf}, you can use the {!query}, {!literal}, {!quote}, {!env}
+  and {!param} printers from this module to generate the corresponding query
+  fragments.
+
+  In addition, you can use the "Q" and "E" string tags to delimit portions of
+  the formatting string that should be interpreted as quotes and environment
+  variables, respectively. The "Q" and "E" tags can not be nested: within the
+  tagsm {!qprintf} behaves no differently than {!asprintf} and will generate a
+  string, not a query (only when the tag is closed does the string get converted
+  into a query).
+
+  The two following calls to {!qprintf}:
+
+    [qprintf "FUNC(@{<Q>Quoted value with %d format(s)})" 1]
+
+  and
+
+    [qprintf "FUNC(%a)" quote (Format.asprintf "Quoted value with %d format(s)" 1)]
+
+  are functionally equivalent. Both compute
+
+    [S [L "FUNC("; Q "Quoted value with 1 format(s)"; L ")"]]
+
+  but the first one is nicer to work with.
+
+  @raise Failure if the "Q" and "E" tags are nested.
+*)
+
+val kqprintf : (t -> 'a) -> ('b, Format.formatter, unit, 'a) format4 -> 'b
+(** {!kqprintf} is the continuation-passing version of {!qprintf} (like
+    {!Format.kasprintf} for {!Format.asprintf}).
+
+    You usually want [qprintf] instead. *)
+
+val param : Format.formatter -> int -> unit
+(** {!param} is a formatter that includes the corresponding parameter in a
+query built by {!qprintf}.
+
+Note that to include a parameter in a query, {!param} *must* be used: using
+literal ["$"] or ["?"] will be sent as-is to the SQL driver and will not be
+processed by Caqti.
+*)
+
+val env : Format.formatter -> string -> unit
+(** {!env} is a formatter that includes the corresponding environment variable
+in a query built by {!qprintf}.
+
+Note that to include an environment variable in a query, {!env} *must* be
+used: using literal ["$(...)"] will be sent as-is to the SQL driver and will
+not be processed by Caqti. *)
+
+val quote : Format.formatter -> string -> unit
+(** {!quote} is a formatter that includes a TEXT literal in a query built by
+{!qprintf}. *)
+
+val query : Format.formatter -> t -> unit
+(** {!query} can be used with {!qprintf} to embed a query that was already
+parsed in the format string. Direct use of {!query} should be rare, and
+{!param}, {!env}, or {!quote} should be used instead when possible.
+
+Using {!query} with any other formatter will ignore the query and instead
+print a dummy value (currently ["... SQL FRAGMENT ..."]) instead. *)

--- a/caqti/lib/caqti_query.mli
+++ b/caqti/lib/caqti_query.mli
@@ -111,32 +111,32 @@ val of_string_exn : string -> t
 val qprintf : ('a, Format.formatter, unit, t) format4 -> 'a
 (** {!qprintf} allows building Caqti queries using a printf-style interface.
 
-  When using {!qprintf}, you can use the {!query}, {!literal}, {!quote}, {!env}
-  and {!param} printers from this module to generate the corresponding query
-  fragments.
+    When using {!qprintf}, you can use the {!query}, {!literal}, {!quote},
+    {!env} and {!param} printers from this module to generate the corresponding
+    query fragments.
 
-  In addition, you can use the "Q" and "E" string tags to delimit portions of
-  the formatting string that should be interpreted as quotes and environment
-  variables, respectively. The "Q" and "E" tags can not be nested: within the
-  tagsm {!qprintf} behaves no differently than {!asprintf} and will generate a
-  string, not a query (only when the tag is closed does the string get converted
-  into a query).
+    In addition, you can use the "Q" and "E" string tags to delimit portions of
+    the formatting string that should be interpreted as quotes and environment
+    variables, respectively. The "Q" and "E" tags can not be nested: within the
+    tags, {!qprintf} behaves no differently than {!asprintf} and will generate
+    a string, not a query (only when the tag is closed does the string get
+    converted into a query).
 
-  The two following calls to {!qprintf}:
+    The two following calls to {!qprintf}:
 
-    [qprintf "FUNC(@{<Q>Quoted value with %d format(s)})" 1]
+      [qprintf "FUNC(@{<Q>Quoted value with %d format(s)})" 1]
 
-  and
+    and
 
-    [qprintf "FUNC(%a)" quote (Format.asprintf "Quoted value with %d format(s)" 1)]
+      [qprintf "FUNC(%a)" quote (Format.asprintf "Quoted value with %d format(s)" 1)]
 
-  are functionally equivalent. Both compute
+    are functionally equivalent. Both compute
 
-    [S [L "FUNC("; Q "Quoted value with 1 format(s)"; L ")"]]
+      [S [L "FUNC("; Q "Quoted value with 1 format(s)"; L ")"]]
 
-  but the first one is nicer to work with.
+    but the first one is nicer to work with.
 
-  @raise Failure if the "Q" and "E" tags are nested.
+    @raise Failure if the "Q" and "E" tags are nested.
 *)
 
 val kqprintf : (t -> 'a) -> ('b, Format.formatter, unit, 'a) format4 -> 'b
@@ -147,29 +147,29 @@ val kqprintf : (t -> 'a) -> ('b, Format.formatter, unit, 'a) format4 -> 'b
 
 val param : Format.formatter -> int -> unit
 (** {!param} is a formatter that includes the corresponding parameter in a
-query built by {!qprintf}.
+    query built by {!qprintf}.
 
-Note that to include a parameter in a query, {!param} *must* be used: using
-literal ["$"] or ["?"] will be sent as-is to the SQL driver and will not be
-processed by Caqti.
+    Note that to include a parameter in a query, {!param} *must* be used: using
+    literal ["$"] or ["?"] will be sent as-is to the SQL driver and will not be
+    processed by Caqti.
 *)
 
 val env : Format.formatter -> string -> unit
 (** {!env} is a formatter that includes the corresponding environment variable
-in a query built by {!qprintf}.
+    in a query built by {!qprintf}.
 
-Note that to include an environment variable in a query, {!env} *must* be
-used: using literal ["$(...)"] will be sent as-is to the SQL driver and will
-not be processed by Caqti. *)
+    Note that to include an environment variable in a query, {!env} *must* be
+    used: using literal ["$(...)"] will be sent as-is to the SQL driver and
+    will not be processed by Caqti. *)
 
 val quote : Format.formatter -> string -> unit
 (** {!quote} is a formatter that includes a TEXT literal in a query built by
-{!qprintf}. *)
+    {!qprintf}. *)
 
 val query : Format.formatter -> t -> unit
 (** {!query} can be used with {!qprintf} to embed a query that was already
-parsed in the format string. Direct use of {!query} should be rare, and
-{!param}, {!env}, or {!quote} should be used instead when possible.
+    parsed in the format string. Direct use of {!query} should be rare, and
+    {!param}, {!env}, or {!quote} should be used instead when possible.
 
-Using {!query} with any other formatter will ignore the query and instead
-print a dummy value (currently ["... SQL FRAGMENT ..."]) instead. *)
+    Using {!query} with any other formatter will ignore the query and instead
+    print a dummy value (currently ["... SQL FRAGMENT ..."]) instead. *)

--- a/caqti/test/test_query.ml
+++ b/caqti/test/test_query.ml
@@ -165,9 +165,23 @@ let test_expand () =
   A.(check query) "same" q1' (Caqti_query.expand env2 q1);
   A.(check query) "same" q1'3 (Caqti_query.expand env3 q1)
 
+let test_qprintf () =
+  let open Caqti_query in
+  let check_expect q1 q2 =
+    A.(check query "same" (normal q1) (normal q2))
+  in
+  check_expect
+    (S [L"SELECT "; P 0; L" WHERE "; Q"quote"; L" = "; E"env"])
+    (qprintf {|%a %a WHERE %a = %a|} query (L"SELECT") param 0 quote "quote" env "env");
+  check_expect
+    (S [L"WHERE "; E"tbl4"; L".name = "; Q"John Wayne"])
+    (qprintf {|WHERE @{<E>tbl%d@}.name = @{<Q>%s Wayne@}|} 4 "John")
+
+
 let test_cases = [
   A.test_case "show, hash" `Quick test_show_and_hash;
   A.test_case "parse special cases" `Quick test_parse_special_cases;
   A.test_case "parse random strings" `Quick test_parse_random_strings;
   A.test_case "expand" `Quick test_expand;
+  A.test_case "qprintf" `Quick test_qprintf;
 ]


### PR DESCRIPTION
Hi, and thanks for building and maintaining this project :)

As I was playing around I realized that there is some tension when building dynamic queries between the recommended way of using `Caqti_query.t` directly and the "convenient" way of building a query string with `Format`. I ended up writing a `qprintf` function that is like `asprintf`, but generates `Caqti_query.t` instead of strings. A more detailed rationale is in the commit message and replicated below; I find it fairly useful and thought others might too.

Sometimes, you need to construct queries dynamically rather than writing them out in code. Building an ORM would be an obvious reason for doing that, but it is quite often that one has to sprinkle a little bit of dynamism here and there.

In the case that one has to generate queries dynamically, the most obvious way coming from standard Caqti usage is to build up a query string fragment using Format or Printf, then use it as if you had written it manually. Simple. But then what happens is that Caqti will take the string that you have built dynamically, and parse it back into a `Caqti_query.t` before using the fragments to build the actual query string.

That doesn't sound very efficient, and relies on you (as the dynamic-query-generator) not messing up the generation of things like quoted strings if you don't want to expose security holes in your software.  In fact, Caqti's documentation quietly recommends using the `Caqti_query.t` type directly when building dynamic queries, touting its easy composability.

While true (`Caqti_query.t` is easily composable), it loses out on convenience compared to the Format + parse approach. For instance, if you want to generate, say, the MAX of two dynamically generated queries, you have to write `S [ L "MAX("; q1; L ", "; q2; L ")" ]`. Maybe if you are keen on combinators, you can figure out how to write a somewhat more readable version such as `l "MAX(" %% q1 % ", " %% q2 % ")"`. But you never get something as nice as the `"MAX(%a, %a)"` that you get with Format.

Or at least, that's what I thought before realizing that format6 is actually *very* polymorphic. It has to, so that it can accomodate the whole family of `*printf` functions. And it turns out that it is polymorphic enough to write a `printf`-style function to build a `Caqti_query.t`.

So here is `qprintf`. Like `sprintf`, but builds a `Caqti_query.t` instead of a `string`. You can delimit quotes and environment variables using tags (`@{<Q>the quote@}` and `@{<E>env.var@}`, respectively), and include parameters with `param`.

This gives a convenient, readable and secure (w.r.t. quoting) way of building queries dynamically, which I thought was worth sharing.