### PR TITLE
[WIP] Add support for array fields.

### DIFF
--- a/caqti-driver-postgresql/lib/dune
+++ b/caqti-driver-postgresql/lib/dune
@@ -1,7 +1,9 @@
-(rule (copy# ../../shared/postgresql_conv.ml postgresql_conv.ml))
+(rule
+ (copy# ../../shared/postgresql_conv.ml postgresql_conv.ml))
 
 (library
  (name caqti_driver_postgresql)
  (public_name caqti-driver-postgresql)
- (library_flags (:standard -linkall))
- (libraries caqti caqti.platform caqti.platform.unix postgresql))
+ (library_flags
+  (:standard -linkall))
+ (libraries angstrom caqti caqti.platform caqti.platform.unix postgresql))

--- a/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml
+++ b/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml
@@ -81,6 +81,7 @@ let no_env _ _ = raise Not_found
 let data_of_value : type a. a Caqti_type.Field.t -> a -> Sqlite3.Data.t =
   fun field_type x ->
   (match field_type with
+   | Array _ -> failwith "arrays not supported by sqlite"
    | Bool   -> Sqlite3.Data.INT (if x then 1L else 0L)
    | Int    -> Sqlite3.Data.INT (Int64.of_int x)
    | Int16  -> Sqlite3.Data.INT (Int64.of_int x)
@@ -122,6 +123,7 @@ let value_of_data
     Request_utils.raise_decode_rejected ~uri ~typ (Caqti_error.Msg msg)
   in
   (match field_type, data with
+   | Array _, _ -> cannot_convert_to "array"
    | Bool, Sqlite3.Data.INT y -> y <> 0L
    | Bool, _ -> cannot_convert_to "bool"
    | Int, Sqlite3.Data.INT y -> Int64.to_int y

--- a/caqti/lib/caqti_type.mli
+++ b/caqti/lib/caqti_type.mli
@@ -32,6 +32,7 @@ type (_, _) eq = Equal : ('a, 'a) eq
 (** Facilities for extending and using primitive field types. *)
 module Field : sig
   type 'a t =
+    | Array : 't t -> 't list t
     | Bool : bool t
     | Int : int t
     | Int16 : int t


### PR DESCRIPTION
This preliminary work adds support for Postgresql's array fields.

AFAIK this is only supported by pg. I do realize this enables writing non-backend-agnostic queries, I'm not sure what the policy is regarding that. In our specific case not being able to use arrays in prepared queries is pretty much a deal breaker as we need to `DELETE FROM _ WHERE id = ANY (?)' with massive arrays of ids, so individual queries won't cut it.

If this is not a no-no from the get-go, this PR has some limitations:

* The decoding of array values is not fully compliant: the items separator can be changed depending on the element type. It is however comma (`,`) for handled atomic types, so I'd say this is good enough for the foreseeable future.
* I wasn't sure what to do with `oid_of_field_type` since I couldn't find a deterministic way to compute it for arrays, but slapping `unknown_oid` doesn't seem to cause any issues, so no harm seen no harm done I suppose.
* I'm not sure of the best way to reject arrays on backend other than Postgres.

Reasonable unit tests included for both encoding and decoding.