### PR TITLE
Fix validation of dead connection in postgresql driver

### DIFF
--- a/caqti-driver-postgresql/lib/caqti_driver_postgresql.ml
+++ b/caqti-driver-postgresql/lib/caqti_driver_postgresql.ml
@@ -882,8 +882,7 @@ struct
             Caqti_error.pp_uri uri (Pg.string_of_error err))
 
     let validate () = using_db @@ fun () ->
-      db#consume_input;
-      if (try db#status = Pg.Ok with Pg.Error _ -> false) then
+      if (try db#consume_input; db#status = Pg.Ok with Pg.Error _ -> false) then
         Fiber.return true
       else
         reset ()


### PR DESCRIPTION
Broken connections may throw on `db#consume_input`. 
Currently, this means that the first attempt to use a dead Postgres connection from the pool (always) fails, rather than reallocating a fresh connection