### PR TITLE
update to tls 1.0.0 API

### DIFF
--- a/caqti-mirage.opam
+++ b/caqti-mirage.opam
@@ -19,12 +19,12 @@ depends: [
   "lwt" {>= "5.3.0"}
   "mirage-channel"
   "mirage-clock"
-  "mirage-random"
+  "mirage-crypto-rng-mirage" {>= "1.0.0"}
   "mirage-time"
   "ocaml"
   "odoc" {with-doc}
   "tls"
-  "tls-mirage"
+  "tls-mirage" {>= "1.0.0"}
   "tcpip" {>= "8.1.0"}
 ]
 build: [

--- a/caqti-mirage/lib/caqti_mirage.ml
+++ b/caqti-mirage/lib/caqti_mirage.ml
@@ -22,7 +22,7 @@ module type SOCKET_OPS =
   Caqti_platform.System_sig.SOCKET_OPS with type 'a fiber := 'a Lwt.t
 
 module Make
-  (RANDOM : Mirage_random.S)
+  (RANDOM : Mirage_crypto_rng_mirage.S)
   (TIME : Mirage_time.S)
   (MCLOCK : Mirage_clock.MCLOCK)
   (PCLOCK : Mirage_clock.PCLOCK)

--- a/caqti-mirage/lib/caqti_mirage.mli
+++ b/caqti-mirage/lib/caqti_mirage.mli
@@ -27,7 +27,7 @@
     MirageOS users on the current API is very welcome. *)
 
 module Make :
-  functor (_ : Mirage_random.S) ->
+  functor (_ : Mirage_crypto_rng_mirage.S) ->
   functor (_ : Mirage_time.S) ->
   functor (_ : Mirage_clock.MCLOCK) ->
   functor (_ : Mirage_clock.PCLOCK) ->

--- a/caqti-mirage/lib/dune
+++ b/caqti-mirage/lib/dune
@@ -15,7 +15,7 @@
     lwt
     mirage-channel
     mirage-clock
-    mirage-random
+    mirage-crypto-rng-mirage
     mirage-time
     tcpip
     tls-mirage))

--- a/caqti-tls.opam
+++ b/caqti-tls.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "3.9"}
   "ocaml"
   "odoc" {with-doc}
-  "tls"
+  "tls" {>= "1.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/caqti-tls/testlib/testlib_tls.enabled.ml
+++ b/caqti-tls/testlib/testlib_tls.enabled.ml
@@ -40,7 +40,9 @@ let () =
     (match x509_authenticator with
      | None -> common_args
      | Some authenticator ->
-        let tls_client_config = Tls.Config.client ~authenticator () in
+        let tls_client_config =
+          Result.get_ok (Tls.Config.client ~authenticator ())
+        in
         let connect_config =
           common_args.connect_config
             |> Caqti_connect_config.set Caqti_tls.Config.client


### PR DESCRIPTION
the two changes are:
- `Tls.Config.client` now returns a result (here, `Result.get_ok` is used to extract the Ok path -- should there be error handling?)
- mirage-random is deprecated, and now replaced by Mirage_crypto_rng_mirage.S directly.