### PR TITLE
caqti-mirage: remove various functors

### DIFF
--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -39,7 +39,7 @@
     caqti-tls-eio
     eio
     eio_main
-    mirage-crypto-rng-eio))
+    mirage-crypto-rng.unix))
 
 (executable
  (name main_lwt_unix)

--- a/benchmarks/main_eio_unix.ml
+++ b/benchmarks/main_eio_unix.ml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2022--2024  Petter A. Urkedal <paurkedal@gmail.com>
+(* Copyright (C) 2022--2025  Petter A. Urkedal <paurkedal@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -33,10 +33,9 @@ include Benchmark_all.Make (struct
   let run_fiber f = f ()
 
   let run_main f =
+    Mirage_crypto_rng_unix.use_default ();
     Eio_main.run @@ fun stdenv ->
     Switch.run @@ fun sw ->
-    Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) stdenv
-      @@ fun () ->
     f ((stdenv :> Caqti_eio.stdenv), sw)
 
   include Caqti_eio

--- a/caqti-eio.opam
+++ b/caqti-eio.opam
@@ -16,8 +16,7 @@ depends: [
   "caqti-driver-sqlite3" {with-test}
   "cmdliner" {with-test & >= "1.1.0"}
   "eio_main" {with-test}
-  "mirage-crypto-rng" {with-test}
-  "mirage-crypto-rng-eio" {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/caqti-mirage.opam
+++ b/caqti-mirage.opam
@@ -18,9 +18,7 @@ depends: [
   "logs"
   "lwt" {>= "5.3.0"}
   "mirage-channel"
-  "mirage-clock"
-  "mirage-crypto-rng-mirage" {>= "1.0.0"}
-  "mirage-time"
+  "mirage-sleep"
   "ocaml"
   "odoc" {with-doc}
   "tls"

--- a/caqti-mirage/lib/caqti_mirage.ml
+++ b/caqti-mirage/lib/caqti_mirage.ml
@@ -22,10 +22,6 @@ module type SOCKET_OPS =
   Caqti_platform.System_sig.SOCKET_OPS with type 'a fiber := 'a Lwt.t
 
 module Make
-  (RANDOM : Mirage_crypto_rng_mirage.S)
-  (TIME : Mirage_time.S)
-  (MCLOCK : Mirage_clock.MCLOCK)
-  (PCLOCK : Mirage_clock.PCLOCK)
   (STACK : Tcpip.Stack.V4V6)
   (DNS : Dns_client_mirage.S) =
 struct
@@ -52,7 +48,7 @@ struct
         if Mtime.is_later t ~than:t_now then 0L else
         Mtime.Span.to_uint64_ns (Mtime.span t t_now)
       in
-      let task = TIME.sleep_ns dt_ns >|= f in
+      let task = Mirage_sleep.ns dt_ns >|= f in
       let hook =
         Caqti_lwt.Switch.on_release_cancellable sw
           (fun () -> Lwt.cancel task; Lwt.return_unit)

--- a/caqti-mirage/lib/caqti_mirage.mli
+++ b/caqti-mirage/lib/caqti_mirage.mli
@@ -27,10 +27,6 @@
     MirageOS users on the current API is very welcome. *)
 
 module Make :
-  functor (_ : Mirage_crypto_rng_mirage.S) ->
-  functor (_ : Mirage_time.S) ->
-  functor (_ : Mirage_clock.MCLOCK) ->
-  functor (_ : Mirage_clock.PCLOCK) ->
   functor (STACK : Tcpip.Stack.V4V6) ->
   functor (DNS : Dns_client_mirage.S) ->
 sig

--- a/caqti-mirage/lib/dune
+++ b/caqti-mirage/lib/dune
@@ -14,8 +14,6 @@
     logs.lwt
     lwt
     mirage-channel
-    mirage-clock
-    mirage-crypto-rng-mirage
-    mirage-time
+    mirage-sleep
     tcpip
     tls-mirage))

--- a/testsuite/dune
+++ b/testsuite/dune
@@ -106,7 +106,7 @@
   (modules main_eio_unix)
   (libraries
     caqti caqti-eio.unix caqti.plugin
-    alcotest eio eio_main mirage-crypto-rng-eio
+    alcotest eio eio_main mirage-crypto-rng.unix
     testlib testlib_eio_unix testsuite))
 
 (rule

--- a/testsuite/main_eio_unix.ml
+++ b/testsuite/main_eio_unix.ml
@@ -1,4 +1,4 @@
-(* Copyright (C) 2022--2024  Petter A. Urkedal <paurkedal@gmail.com>
+(* Copyright (C) 2022--2025  Petter A. Urkedal <paurkedal@gmail.com>
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -73,10 +73,9 @@ let mk_tests (stdenv, sw) {uris; connect_config} =
   List.map (mk_test % create_target) uris
 
 let () =
+  Mirage_crypto_rng_unix.use_default ();
   Eio_main.run @@ fun stdenv ->
   Switch.run @@ fun sw ->
-  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) stdenv
-    @@ fun () ->
   Alcotest_cli.run_with_args_dependency "test_sql_eio"
     (Testlib.common_args ())
     (mk_tests ((stdenv :> Caqti_eio.stdenv), sw))


### PR DESCRIPTION
With the rise to use dune variants (the linking trick) instead of functorizing everything over random, time, mclock, pclock -- I'm delighted to propose this PR which removes these functor arguments.

The provided unikernel will need to be updated, but unfortunately we'll need to first cut a release of mirage, the tool, itself. This is in progress and hopefully finished this week or next week.