### PR TITLE
fix: caqti request id is not thread safe

### DIFF
--- a/caqti.opam
+++ b/caqti.opam
@@ -27,6 +27,7 @@ depends: [
   "ptime"
   "re" {with-test}
   "tls"
+  "atomic"
   "uri" {>= "2.2.0"}
   "x509"
 ]

--- a/caqti/lib/caqti_request.ml
+++ b/caqti/lib/caqti_request.ml
@@ -26,10 +26,10 @@ type ('a, 'b, +'m) t = {
   row_mult: 'm Caqti_mult.t;
 } constraint 'm = [< `Zero | `One | `Many]
 
-let last_id = ref (-1)
+let last_id = Atomic.make (-1)
 
 let create ?(oneshot = false) param_type row_type row_mult query =
-  let id = if oneshot then None else (incr last_id; Some !last_id) in
+  let id = if oneshot then None else Some (Atomic.fetch_and_add last_id 1) in
   {id; query; param_type; row_type; row_mult}
 
 let param_type request = request.param_type

--- a/caqti/lib/dune
+++ b/caqti/lib/dune
@@ -3,4 +3,4 @@
  (public_name caqti)
  (wrapped false)
  (library_flags (:standard -linkall))
- (libraries angstrom bigstringaf logs mtime ptime uri))
+ (libraries angstrom bigstringaf logs mtime ptime uri atomic))


### PR DESCRIPTION
this means 2 threads/domains could allocate distinct requests with the
same ID, which would then be confused for one another in a connection's cache
