### PR TITLE
Scope rule depending on sqlite3 to caqti-driver-sqlite3.

### DIFF
--- a/caqti-driver-sqlite3/lib/dune
+++ b/caqti-driver-sqlite3/lib/dune
@@ -12,8 +12,10 @@
  (site (caqti plugins)))
 
 (rule
+ (package caqti-driver-sqlite3)
  (enabled_if (>= %{version:sqlite3} 5.2.0))
  (action (copy# sqlite3_shim.5.2.ml sqlite3_shim.ml)))
 (rule
+ (package caqti-driver-sqlite3)
  (enabled_if (< %{version:sqlite3} 5.2.0))
  (action (copy# sqlite3_shim.fallback.ml sqlite3_shim.ml)))


### PR DESCRIPTION
Otherwise when using `dune pkg`, this rule would trigger with eg. `dune build -p caqti-lwt`, which would fail since sqlite is not installed at that point.