### PR TITLE
Document: Caqti_pool_sig.drain closes resources once they are *idle*

### DIFF
--- a/caqti/lib/caqti_pool_sig.ml
+++ b/caqti/lib/caqti_pool_sig.ml
@@ -37,7 +37,8 @@ module type S = sig
         The default priority is [0.0]. *)
 
   val drain : ('a, 'e) t -> unit fiber
-  (** [drain pool] closes all resources in [pool]. The pool is still usable, as
-      new resources will be created on demand. *)
+  (** [drain pool] closes all resources in [pool] once they become {e idle}.
+      The pool is still usable, as new resources will be created on demand.
+      Resources are not closed while they are in use. *)
 
 end


### PR DESCRIPTION
The documentation before could be interpreted as it would close all connections even ones in use. Study of the code seems to show that it only closes resources (connections) once they become idle/not in use.
https://github.com/paurkedal/ocaml-caqti/blob/03637f374f042bf7e73dfcce767487edab95b3c9/caqti/lib-platform/pool.ml#L313-L336

As I understand it the resources in `pool.queue` are resources not currently in use. If the pool is non-empty and the queue is empty we wait. We wait with priority `0.0` which is the default priority for `use` as well, so as far as I can tell we can have that `drain` has to wait after new calls to `use`, and could with unfortunate scheduling wait indefinitely. I did not try to document this.

First commit is when I didn't realize that `drain` *waits* for resources to become idle. So I suggest squashing the commits (or I can squash them).